### PR TITLE
added mass_action_reactions field to reaction_network

### DIFF
--- a/src/maketype.jl
+++ b/src/maketype.jl
@@ -12,6 +12,7 @@ function maketype(name,
                   params = Symbol[],
                   pfuncs=Vector{Expr}(0),
                   symjac=Matrix{SymEngine.Basic}(0,0),
+                  reactions=Vector{ReactionStruct}()
                   )
 
     typeex = :(mutable struct $name <: AbstractReactionNetwork
@@ -27,6 +28,7 @@ function maketype(name,
         syms::Vector{Symbol}
         params::Vector{Symbol}
         symjac::Matrix{SymEngine.Basic}
+        reactions::Vector{ReactionStruct}
     end)
     # Make the default constructor
     constructorex = :($(name)(;
@@ -41,7 +43,8 @@ function maketype(name,
                   $(Expr(:kw,:f_symfuncs,f_symfuncs)),
                   $(Expr(:kw,:syms,syms)),
                   $(Expr(:kw,:params,params)),
-                  $(Expr(:kw,:symjac,symjac))) =
+                  $(Expr(:kw,:symjac,symjac)),
+                  $(Expr(:kw,:reactions,reactions))) =
                   $(name)(
                       f,
                       f_func,
@@ -55,6 +58,7 @@ function maketype(name,
                       syms,
                       params,
                       symjac,
+                      reactions
                       )) |> esc
 
                       #f_funcs,symfuncs,pfuncs,syms,symjac) |> esc

--- a/src/reaction_network.jl
+++ b/src/reaction_network.jl
@@ -104,7 +104,8 @@ function coordinate(name, ex::Expr, p, scale_noise)
     f_funcs = [element.args[2] for element in f_expr]
     g_funcs = [element.args[2] for element in g_expr]
 
-    typeex,constructorex = maketype(name, f, f_funcs, f_symfuncs, g, g_funcs, jumps, Meta.quot(jump_rate_expr), Meta.quot(jump_affect_expr), p_matrix, syms; params=params)
+    typeex,constructorex = maketype(name, f, f_funcs, f_symfuncs, g, g_funcs, jumps, Meta.quot(jump_rate_expr), Meta.quot(jump_affect_expr), p_matrix, syms; params=params, reactions=reactions)
+
     push!(exprs,typeex)
     push!(exprs,constructorex)
 


### PR DESCRIPTION
added `mass_action_reaction` field to generated `reaction_network`. This field simply stores the `Vector{ReactionStruct}` generated in parsing the network, which contains additional stochiometric info.