### PR TITLE
Remove SymJac calculation

### DIFF
--- a/src/reaction_network.jl
+++ b/src/reaction_network.jl
@@ -94,7 +94,7 @@ function coordinate(name, ex::Expr, p, scale_noise)
     jumps = get_jumps(jump_rate_expr, jump_affect_expr,reactants,parameters)
 
     f_rhs = [element.args[2] for element in f_expr]
-    symjac = Expr(:quote, calculate_jac(f_rhs, syms))
+    #symjac = Expr(:quote, calculate_jac(f_rhs, syms))
     f_symfuncs = hcat([SymEngine.Basic(f) for f in f_rhs])
 
     # Build the type
@@ -104,7 +104,7 @@ function coordinate(name, ex::Expr, p, scale_noise)
     f_funcs = [element.args[2] for element in f_expr]
     g_funcs = [element.args[2] for element in g_expr]
 
-    typeex,constructorex = maketype(name, f, f_funcs, f_symfuncs, g, g_funcs, jumps, Meta.quot(jump_rate_expr), Meta.quot(jump_affect_expr), p_matrix, syms; params=params, symjac=symjac)
+    typeex,constructorex = maketype(name, f, f_funcs, f_symfuncs, g, g_funcs, jumps, Meta.quot(jump_rate_expr), Meta.quot(jump_affect_expr), p_matrix, syms; params=params)
     push!(exprs,typeex)
     push!(exprs,constructorex)
 


### PR DESCRIPTION
Since not actually used and caused issues with some input ('E', 'I', 'e') I removed the symjac calculation.

All the code is still there so we could easily add it back in if we want to, or if in the future it is calculated elsewhere we could remove the stuff related to it all together.