### PR TITLE
Added usage of VariableRateJumps in addition to ConstantRateJumps

### DIFF
--- a/src/maketype.jl
+++ b/src/maketype.jl
@@ -20,7 +20,7 @@ function maketype(name,
         f_symfuncs::Matrix{SymEngine.Basic}
         g::Function
         g_func::Vector{Any}
-        jumps::Tuple{ConstantRateJump,Vararg{ConstantRateJump}}
+        jumps::Tuple{AbstractJump,Vararg{AbstractJump}}
         jump_rate_expr::Tuple{Any,Vararg{Any}}
         jump_affect_expr::Tuple{Vector{Expr},Vararg{Vector{Expr}}}
         p_matrix::Array{Float64,2}

--- a/src/problem.jl
+++ b/src/problem.jl
@@ -8,7 +8,7 @@ DiffEqBase.SDEProblem(rn::AbstractReactionNetwork, args...; kwargs...) =
 
 ### JumpProblem ###
 function DiffEqJump.JumpProblem(prob,aggregator::Direct,rn::AbstractReactionNetwork; kwargs...)
-    if typeof(prob)<:DiscreteProblem && any(issubtype.(typeof.(equi_model.jumps),VariableRateJump))
+    if typeof(prob)<:DiscreteProblem && any(issubtype.(typeof.(rn.jumps),VariableRateJump))
         error("When using time dependant reaction rates a DiscreteProblem should not be used (try an ODEProblem). Also, use a continious solver.")
     end
     JumpProblem(prob,aggregator::Direct,rn.jumps...;kwargs...)

--- a/src/problem.jl
+++ b/src/problem.jl
@@ -7,8 +7,12 @@ DiffEqBase.SDEProblem(rn::AbstractReactionNetwork, args...; kwargs...) =
     SDEProblem(rn.f,rn.g, args...;noise_rate_prototype=rn.p_matrix, kwargs...)
 
 ### JumpProblem ###
-DiffEqJump.JumpProblem(prob,aggregator::Direct,rn::AbstractReactionNetwork; kwargs...) =
+function DiffEqJump.JumpProblem(prob,aggregator::Direct,rn::AbstractReactionNetwork; kwargs...)
+    if typeof(prob)<:DiscreteProblem && any(issubtype.(typeof.(equi_model.jumps),VariableRateJump))
+        error("When using time dependant reaction rates a DiscreteProblem should not be used (try an ODEProblem). Also, use a continious solver.")
+    end
     JumpProblem(prob,aggregator::Direct,rn.jumps...;kwargs...)
+end
 
 ### SteadyStateProblem ###
 DiffEqBase.SteadyStateProblem(rn::AbstractReactionNetwork, args...; kwargs...) =

--- a/src/problem.jl
+++ b/src/problem.jl
@@ -8,9 +8,6 @@ DiffEqBase.SDEProblem(rn::AbstractReactionNetwork, args...; kwargs...) =
 
 ### JumpProblem ###
 DiffEqJump.JumpProblem(prob,aggregator::Direct,rn::AbstractReactionNetwork; kwargs...) =
-    if typeof(prob)<:DiscreteProblem && any(issubtype.(typeof.(equi_model.jumps),VariableRateJump))
-        error("When using time dependant reaction rates a DiscreteProblem should not be used (try an ODEProblem). Also, use a continious solver.")
-    end
     JumpProblem(prob,aggregator::Direct,rn.jumps...;kwargs...)
 
 ### SteadyStateProblem ###

--- a/src/problem.jl
+++ b/src/problem.jl
@@ -8,6 +8,9 @@ DiffEqBase.SDEProblem(rn::AbstractReactionNetwork, args...; kwargs...) =
 
 ### JumpProblem ###
 DiffEqJump.JumpProblem(prob,aggregator::Direct,rn::AbstractReactionNetwork; kwargs...) =
+    if typeof(prob)<:DiscreteProblem && any(issubtype.(typeof.(equi_model.jumps),VariableRateJump))
+        error("When using time dependant reaction rates a DiscreteProblem should not be used (try an ODEProblem). Also, use a continious solver.")
+    end
     JumpProblem(prob,aggregator::Direct,rn.jumps...;kwargs...)
 
 ### SteadyStateProblem ###

--- a/src/reaction_network.jl
+++ b/src/reaction_network.jl
@@ -369,6 +369,15 @@ function recursive_replace!(expr::Any, replace_requests::Tuple{OrderedDict{Symbo
     return expr
 end
 
+#Recursive Contains, checks whenever an expression contains a certain symbol.
+function recursive_contains(s,ex)
+    (typeof(ex)!=Expr) && (return s==ex)
+    for arg in ex.args
+        recursive_contains(s,arg) && (return true)
+    end
+    return false
+end
+
 #Makes the Jacobian.
 function calculate_jac(f_expr::Vector{Expr}, syms)
     symjac = Matrix{SymEngine.Basic}( length(syms), length(syms))

--- a/src/reaction_network.jl
+++ b/src/reaction_network.jl
@@ -308,7 +308,7 @@ end
 function get_jumps(rates::Tuple, affects::Tuple,reactants::OrderedDict{Symbol,Int},parameters::OrderedDict{Symbol,Int})
     jumps = Expr(:tuple)
     for i = 1:length(rates)
-        push!(jumps.args,Expr(:call,:ConstantRateJump))
+        recursive_contains(:t,rates[i]) ? push!(jumps.args,Expr(:call,:VariableRateJump)) : push!(jumps.args,Expr(:call,:ConstantRateJump))
         push!(jumps.args[i].args, :((internal_var___u,internal_var___p,t) -> $(recursive_replace!(deepcopy(rates[i]), (reactants,:internal_var___u), (parameters, :internal_var___p)))))
         push!(jumps.args[i].args, :(integrator -> $(expr_arr_to_block(deepcopy(affects[i])))))
     end

--- a/src/reaction_network.jl
+++ b/src/reaction_network.jl
@@ -309,8 +309,6 @@ function get_jumps(rates::Tuple, affects::Tuple,reactants::OrderedDict{Symbol,In
     jumps = Expr(:tuple)
     for i = 1:length(rates)
         push!(jumps.args,Expr(:call,:ConstantRateJump))
-    end
-    for i = 1:length(rates)
         push!(jumps.args[i].args, :((internal_var___u,internal_var___p,t) -> $(recursive_replace!(deepcopy(rates[i]), (reactants,:internal_var___u), (parameters, :internal_var___p)))))
         push!(jumps.args[i].args, :(integrator -> $(expr_arr_to_block(deepcopy(affects[i])))))
     end


### PR DESCRIPTION
I think I know what I am doing, I have never really used the VariableRateJumps before. But after reading some I think I understood that those should be used when e.g. the rate depends on time.

Previously only ContantRateJumps were used (for SSA). Now it will be checked whenever a reaction has a reaction rate which depends on t. If that is the case a VariableRateJump will be used instead of a ConstantRateJump for that reaction.

If such a reaction is present (and hence a VariableRateJump) something like
```julia
prob = ODEProblem(model,u0,tspan)
jump_prob = JumpProblem(prob,Direct(),model)
sol = solve(jump_prob,Tsit5())
```
should be used, rather than:
```julia

prob = DiscreteProblem(u0,tspan)
jump_prob = JumpProblem(prob,Direct(),model)
sol = solve(jump_prob,FunctionMap())
```
(I am right here? The docs do not directly say that DiscreteProblems cannot be used, but I got strange behaviour when I tried it)

Since this seems like a likely error to do (if it actually is an error) I added a message for anyone trying to declare a jump problem using a DiscreteProblem and VariableRateJumps.
