### PR TITLE
New 

### DIFF
--- a/src/reaction_network.jl
+++ b/src/reaction_network.jl
@@ -60,8 +60,8 @@ macro reaction_network(name, scale_noise, ex::Expr, p...)
 end
 
 #Used to give a warning if someone uses the old macro.
-macro reaction_network(ex::Expr)
-    error("The Reaction Network DSL have been deprecated in favor for a new one. With only slight modification old code can be made to work with the new DSL. In addition the new one provides lots of additional functionality. Please view the documentation for more information.")
+macro reaction_network(ex::Expr, p...)
+    coordinate(:reaction_network, ex, p, :no___noise___scaling)
 end
 
 #Declare various arrow types symbols used for the empty set (also 0).


### PR DESCRIPTION
Currently, if one makes a reaction network without giving a type name like:
```julia
equi_model = @reaction_network begin
    1, 0 --> X
    2.5, X + Y --> Z
    Z, Z --> X
end
```
a warning was given that the DSL had been deprecated in favour of a new one which should be called e.g. using
```julia
equi_model = @reaction_network rn_type begin
    1, 0 --> X
    2.5, X + Y --> Z
    Z, Z --> X
end
```
However in many situations one do not need to designate a specific type and it would be simpler to use the first syntax. At some point we should switch to allow the first syntax as well (which simply calls the second one with a default type, `reaction_network`). This depends on when we think we may remove the deprecation warning though.

(This Pull request would make just that change)