### PR TITLE
More diverse input options

### DIFF
--- a/src/reaction_network.jl
+++ b/src/reaction_network.jl
@@ -55,8 +55,10 @@ end
 
 #Macro to create a reaction network model. Multiple dispatch is used to allow for SDE noise scalling.
 macro reaction_network(sym1, sym2, ex::Expr, p...)
+    println(typeof(sym1)," ",typeof(sym2), " ",typeof(p))
+    println(sym1," ",sym2, " ",p)
     in(sym1,p) $ in(sym2,p) || error("Two initial options have been given (designating type and noise scaling). However, exactly one of these must also be given as a parameter")
-    in(sym1,p) && coordinate(sym2,ex,p,sym1) : coordinate(sym1,ex,p,sym2)
+    in(sym1,p) ? coordinate(sym2,ex,p,sym1) : coordinate(sym1,ex,p,sym2)
 end
 
 #Used to give a warning if someone uses the old macro.

--- a/src/reaction_network.jl
+++ b/src/reaction_network.jl
@@ -54,7 +54,7 @@ macro reaction_network(sym, ex::Expr, p...)
 end
 
 #Macro to create a reaction network model. Multiple dispatch is used to allow for SDE noise scalling.
-macro reaction_network(name, scale_noise, ex::Expr, p...)
+macro reaction_network(sym1, sym2, ex::Expr, p...)
     in(sym1,p) $ in(sym2,p) || error("Two initial options have been given (designating type and noise scaling). However, exactly one of these must also be given as a parameter")
     in(sym1,p) && coordinate(sym2,ex,p,sym1) : coordinate(sym1,ex,p,sym2)
 end

--- a/src/reaction_network.jl
+++ b/src/reaction_network.jl
@@ -49,14 +49,14 @@ Example systems:
 """
 
 #Macro to create a reaction network model.
-macro reaction_network(name, ex::Expr, p...)
-    coordinate(name, ex, p, :no___noise___scaling)
+macro reaction_network(sym, ex::Expr, p...)
+    in(sym,p) ? coordinate(:reaction_network,ex,p,sym) : coordinate(sym,ex,p,:no___noise___scaling)
 end
 
 #Macro to create a reaction network model. Multiple dispatch is used to allow for SDE noise scalling.
 macro reaction_network(name, scale_noise, ex::Expr, p...)
-    in(scale_noise, p) || (p = (p..., scale_noise))
-    coordinate(name, ex, p, scale_noise)
+    in(sym1,p) $ in(sym2,p) || error("Two initial options have been given (designating type and noise scaling). However, exactly one of these must also be given as a parameter")
+    in(sym1,p) && coordinate(sym2,ex,p,sym1) : coordinate(sym1,ex,p,sym2)
 end
 
 #Used to give a warning if someone uses the old macro.

--- a/src/reaction_network.jl
+++ b/src/reaction_network.jl
@@ -55,8 +55,6 @@ end
 
 #Macro to create a reaction network model. Multiple dispatch is used to allow for SDE noise scalling.
 macro reaction_network(sym1, sym2, ex::Expr, p...)
-    println(typeof(sym1)," ",typeof(sym2), " ",typeof(p))
-    println(sym1," ",sym2, " ",p)
     in(sym1,p) $ in(sym2,p) || error("Two initial options have been given (designating type and noise scaling). However, exactly one of these must also be given as a parameter")
     in(sym1,p) ? coordinate(sym2,ex,p,sym1) : coordinate(sym1,ex,p,sym2)
 end

--- a/src/reaction_network.jl
+++ b/src/reaction_network.jl
@@ -49,14 +49,14 @@ Example systems:
 """
 
 #Macro to create a reaction network model.
-macro reaction_network(name, ex::Expr, p...)
-    coordinate(name, ex, p, :no___noise___scaling)
+macro reaction_network(sym, ex::Expr, p...)
+    in(sym,p) ? coordinate(:reaction_network,ex,p,sym) : coordinate(sym,ex,p,:no___noise___scaling)
 end
 
 #Macro to create a reaction network model. Multiple dispatch is used to allow for SDE noise scalling.
-macro reaction_network(name, scale_noise, ex::Expr, p...)
-    in(scale_noise, p) || (p = (p..., scale_noise))
-    coordinate(name, ex, p, scale_noise)
+macro reaction_network(sym1, sym2, ex::Expr, p...)
+    in(sym1,p) $ in(sym2,p) || error("Two initial options have been given (designating type and noise scaling). However, exactly one of these must also be given as a parameter")
+    in(sym1,p) ? coordinate(sym2,ex,p,sym1) : coordinate(sym1,ex,p,sym2)
 end
 
 #Used to give a warning if someone uses the old macro.

--- a/src/reaction_network.jl
+++ b/src/reaction_network.jl
@@ -49,14 +49,14 @@ Example systems:
 """
 
 #Macro to create a reaction network model.
-macro reaction_network(sym, ex::Expr, p...)
-    in(sym,p) ? coordinate(:reaction_network,ex,p,sym) : coordinate(sym,ex,p,:no___noise___scaling)
+macro reaction_network(name, ex::Expr, p...)
+    coordinate(name, ex, p, :no___noise___scaling)
 end
 
 #Macro to create a reaction network model. Multiple dispatch is used to allow for SDE noise scalling.
-macro reaction_network(sym1, sym2, ex::Expr, p...)
-    in(sym1,p) $ in(sym2,p) || error("Two initial options have been given (designating type and noise scaling). However, exactly one of these must also be given as a parameter")
-    in(sym1,p) ? coordinate(sym2,ex,p,sym1) : coordinate(sym1,ex,p,sym2)
+macro reaction_network(name, scale_noise, ex::Expr, p...)
+    in(scale_noise, p) || (p = (p..., scale_noise))
+    coordinate(name, ex, p, scale_noise)
 end
 
 #Used to give a warning if someone uses the old macro.

--- a/test/func_test.jl
+++ b/test/func_test.jl
@@ -34,10 +34,10 @@ model1 = @reaction_network rn begin
 end
 model2 = @reaction_network rn η begin
     (5,5000), X ↔ 0
-end
+end η
 model3 = @reaction_network rn η begin
     (1,5000), X ↔ 0
-end
+end η
 function tmp_std(sol)
     vect = Vector{Float64}(length(sol.u))
     for i = 1:length(sol.u)


### PR DESCRIPTION
Till allows you to
- Only input a noise scaling parameter.
- Input Noise scaling and a custom type in any order.

Also:
- The noise scaling parameter is now required to be among the parameters (where it earlier simply was optional.

E.g. this becomes a possible input:
```julia
equi_model = @reaction_network η typeR begin
    1, 0 --> X
    k, X + Y --> Z
    Z, Z --> X
end η k
```
```julia
equi_model = @reaction_network η begin
    1, 0 --> X
    2, X + Y --> Z
    Z, Z --> X
end η
```