### PR TITLE
Updated ReactionStruct Structure

### DIFF
--- a/src/reaction_network.jl
+++ b/src/reaction_network.jl
@@ -310,6 +310,7 @@ function make_func(func_expr::Vector{Expr},reactants::OrderedDict{Symbol,Int},pa
     return :((internal_var___du,internal_var___u,internal_var___p,t) -> $system)
 end
 
+#Creates expressions for jump affects and rates. Also creates and array with MassAction, ConstantRate and VariableRate Jumps.
 function get_jumps(reactions::Vector{ReactionStruct}, reactants::OrderedDict{Symbol,Int})
     rates = Vector{Any}(length(reactions))
     affects = Vector{Vector{Expr}}(length(reactions))

--- a/src/reaction_network.jl
+++ b/src/reaction_network.jl
@@ -398,7 +398,7 @@ function recursive_contains(s,ex)
 end
 
 #Parses an expression, and returns a set with all symbols in the expression, which is also a part of the provided vector with symbols (syms).
-function recursive_content(ex,syms::Vector{Symbol},content::Vector{Symbol}
+function recursive_content(ex,syms::Vector{Symbol},content::Vector{Symbol})
     if typeof(ex)!=Expr
         in(ex,syms) && push!(content,ex)
     else

--- a/src/reaction_network.jl
+++ b/src/reaction_network.jl
@@ -154,11 +154,11 @@ end
 struct ReactionStruct
     substrates::Vector{ReactantStruct}
     products::Vector{ReactantStruct}
-    rate_org
-    rate_DE
-    rate_SSA
+    rate_org::Any
+    rate_DE::Any
+    rate_SSA::Any
     dependants::Vector{Symbol}
-    is_pure_mass_action::Boolean
+    is_pure_mass_action::Bool
 
     function ReactionStruct(sub_line::Any, prod_line::Any, rate::Any, use_mass_kin::Bool)
         sub = add_reactants!(sub_line,1,Vector{ReactantStruct}(0))

--- a/src/reaction_network.jl
+++ b/src/reaction_network.jl
@@ -92,8 +92,7 @@ function coordinate(name, ex::Expr, p, scale_noise)
     g = make_func(g_expr, reactants, parameters)
     p_matrix = zeros(length(reactants), length(reactions))
 
-    (jump_rate_expr, jump_affect_expr) = get_jump_expr(reactions, reactants)
-    jumps = get_jumps(jump_rate_expr, jump_affect_expr,reactants,parameters)
+    (jump_rate_expr, jump_affect_expr, jumps) = get_jumps(reactions, reactants,parameters)
 
     f_rhs = [element.args[2] for element in f_expr]
     #symjac = Expr(:quote, calculate_jac(f_rhs, syms))

--- a/src/reaction_network.jl
+++ b/src/reaction_network.jl
@@ -163,7 +163,12 @@ struct ReactionStruct
     function ReactionStruct(sub_line::Any, prod_line::Any, rate::Any, use_mass_kin::Bool)
         sub = add_reactants!(sub_line,1,Vector{ReactantStruct}(0))
         prod = add_reactants!(prod_line,1,Vector{ReactantStruct}(0))
-        new(sub,prod,use_mass_kin ? mass_rate(sub,rate) : rate, use_mass_kin, rate)
+        #new(sub,prod,use_mass_kin ? mass_rate(sub,rate) : rate, use_mass_kin, rate)
+
+        rate_DE =  Expr(:call, :*, rate, mass_rate_DE(sub, use_mass_kin))
+        rate_SSA =  Expr(:call, :*, rate, mass_rate_SSA(sub, use_mass_kin))
+        is_pure_mass_action = !(use_mass_kin) && (length(recursive_content(reaction.rate_DE,syms,Set{Symbol}([]))))
+        new(sub, prod, rate, rate_DE, rate_SSA, use_mass_kin, nothing)
     end
 end
 

--- a/src/reaction_network.jl
+++ b/src/reaction_network.jl
@@ -321,17 +321,17 @@ function get_jumps(reactions::Vector{ReactionStruct}, reactants::OrderedDict{Sym
         affects[idx] = Vector{Expr}(0)
         foreach(prod -> push!(affects[idx],:(@inbounds integrator.u[$(reactants[prod.reactant])] += $(prod.stoichiometry))), reaction.products)
         foreach(sub -> push!(affects[idx],:(@inbounds integrator.u[$(reactants[sub.reactant])] -= $(sub.stoichiometry))), reaction.substrates)
-        if reaction.is_pure_mass_action
-            ma_sub_stoch = :(reactant_stoich = [[]])
-            ma_stoch_change = :(reactant_stoich = [[]])
-            foreach(sub -> push!(ma_sub_stoch.args[2].args[1].args),:($(reactants[sub.reactant])=>$(sub.stoichiometry)),reaction.substrates)
-            foreach(reactant -> push!(ma_stoch_change.args[2].args[1].args),:($(reactants[reactant.reactant])=>$(get_stoch_diff(reaction,reactant))),reaction.substrates)
-            push!(jumps.args,:(MassActionJump($(reaction.rate_org),$(ma_sub_stoch),$(ma_stoch_change))))
-        else
+        #if reaction.is_pure_mass_action
+        #    ma_sub_stoch = :(reactant_stoich = [[]])
+        #    ma_stoch_change = :(reactant_stoich = [[]])
+        #    foreach(sub -> push!(ma_sub_stoch.args[2].args[1].args),:($(reactants[sub.reactant])=>$(sub.stoichiometry)),reaction.substrates)
+        #    foreach(reactant -> push!(ma_stoch_change.args[2].args[1].args),:($(reactants[reactant.reactant])=>$(get_stoch_diff(reaction,reactant))),reaction.substrates)
+        #    push!(jumps.args,:(MassActionJump($(reaction.rate_org),$(ma_sub_stoch),$(ma_stoch_change))))
+        #else
             recursive_contains(:t,rates[i]) ? push!(jumps.args,Expr(:call,:VariableRateJump)) : push!(jumps.args,Expr(:call,:ConstantRateJump))
             push!(jumps.args[i].args, :((internal_var___u,internal_var___p,t) -> $(recursive_replace!(deepcopy(rates[idx]), (reactants,:internal_var___u), (parameters, :internal_var___p)))))
             push!(jumps.args[i].args, :(integrator -> $(expr_arr_to_block(deepcopy(affects[idx])))))
-        end
+        #end
     end
     return (Tuple(rates),Tuple(affects),jumps)
 end

--- a/src/reaction_network.jl
+++ b/src/reaction_network.jl
@@ -162,11 +162,9 @@ struct ReactionStruct
     function ReactionStruct(sub_line::Any, prod_line::Any, rate::Any, use_mass_kin::Bool)
         sub = add_reactants!(sub_line,1,Vector{ReactantStruct}(0))
         prod = add_reactants!(prod_line,1,Vector{ReactantStruct}(0))
-        #new(sub,prod,use_mass_kin ? mass_rate(sub,rate) : rate, use_mass_kin, rate)
 
         rate_DE = mass_rate_DE(sub, use_mass_kin, rate)
         rate_SSA =  mass_rate_SSA(sub, use_mass_kin, rate)
-        is_pure_mass_action = !(use_mass_kin) && (length(recursive_content(reaction.rate_DE,syms,Vector{Symbol}())))
         new(sub, prod, rate, rate_DE, rate_SSA, [], use_mass_kin)
     end
     function ReactionStruct(r::ReactionStruct, syms::Vector{Symbol})

--- a/src/reaction_network.jl
+++ b/src/reaction_network.jl
@@ -154,10 +154,12 @@ end
 struct ReactionStruct
     substrates::Vector{ReactantStruct}
     products::Vector{ReactantStruct}
-    rate
-    use_mass_kin::Bool
-    input_rate #Saved and used when making jump, since (discrete) jumps make
-               #reaction rates differently from ODE/SDE.
+    rate_org
+    rate_DE
+    rate_SSA
+    is_pure_mass_action::Boolean
+    dependants::Vector{Symbol}
+
     function ReactionStruct(sub_line::Any, prod_line::Any, rate::Any, use_mass_kin::Bool)
         sub = add_reactants!(sub_line,1,Vector{ReactantStruct}(0))
         prod = add_reactants!(prod_line,1,Vector{ReactantStruct}(0))

--- a/src/reaction_network.jl
+++ b/src/reaction_network.jl
@@ -353,8 +353,8 @@ function get_jumps(reactions::Vector{ReactionStruct}, reactants::OrderedDict{Sym
             push!(jumps.args,:(MassActionJump($(reaction.rate_org),$(ma_sub_stoch),$(ma_stoch_change))))
         else
             recursive_contains(:t,rates[i]) ? push!(jumps.args,Expr(:call,:VariableRateJump)) : push!(jumps.args,Expr(:call,:ConstantRateJump))
-            push!(jumps.args[i].args, :((internal_var___u,internal_var___p,t) -> $(recursive_replace!(deepcopy(rates[i]), (reactants,:internal_var___u), (parameters, :internal_var___p)))))
-            push!(jumps.args[i].args, :(integrator -> $(expr_arr_to_block(deepcopy(affects[i])))))
+            push!(jumps.args[i].args, :((internal_var___u,internal_var___p,t) -> $(recursive_replace!(deepcopy(rates[idx]), (reactants,:internal_var___u), (parameters, :internal_var___p)))))
+            push!(jumps.args[i].args, :(integrator -> $(expr_arr_to_block(deepcopy(affects[idx])))))
         end
     end
     return (Tuple(rates),Tuple(affects),jumps)

--- a/src/reaction_network.jl
+++ b/src/reaction_network.jl
@@ -167,7 +167,7 @@ struct ReactionStruct
         rate_DE = mass_rate_DE(sub, use_mass_kin, rate)
         rate_SSA =  mass_rate_SSA(sub, use_mass_kin, rate)
         is_pure_mass_action = !(use_mass_kin) && (length(recursive_content(reaction.rate_DE,syms,Set{Symbol}([]))))
-        new(sub, prod, rate, rate_DE, rate_SSA, nothing, use_mass_kin)
+        new(sub, prod, rate, rate_DE, rate_SSA, [], use_mass_kin)
     end
     function ReactionStruct(r::ReactionStruct, syms::Vector{Symbol})
         deps = recursive_content(reaction.rate_DE,syms,Set{Symbol}([]))
@@ -186,7 +186,7 @@ end
 #Calculates the rate used by SSAs. If we want to use masskinetics we have to include substrate concentration, taking higher order terms into account.
 function mass_rate_SSA(substrates::Vector{ReactantStruct}, use_mass_kin::Bool, old_rate::Any)
     rate = Expr(:call, :*, old_rate)
-    use_mass_kin && foreach(sub -> push!(rate.args, :(binomial($(sub.reactant),$(sub.stoichiometry)))),reaction.substrates)
+    use_mass_kin && foreach(sub -> push!(rate.args, :(binomial($(sub.reactant),$(sub.stoichiometry)))), substrates)
     return rate
 end
 


### PR DESCRIPTION
The `ReactionStruct` structure now contains these fields:
```julia
    substrates::Vector{ReactantStruct}
    products::Vector{ReactantStruct}
    rate_org::Any
    rate_DE::Any
    rate_SSA::Any
    dependants::Vector{Symbol}
    is_pure_mass_action::Bool
```