### PR TITLE
Regular jumps

### DIFF
--- a/src/maketype.jl
+++ b/src/maketype.jl
@@ -5,6 +5,7 @@ function maketype(name,
                   g,
                   g_func,
                   jumps,
+                  regular_jumps,
                   jump_rate_expr,
                   jump_affect_expr,
                   p_matrix,
@@ -22,6 +23,7 @@ function maketype(name,
         g::Function
         g_func::Vector{Any}
         jumps::Tuple{AbstractJump,Vararg{AbstractJump}}
+        regular_jumps::RegularJump
         jump_rate_expr::Tuple{Any,Vararg{Any}}
         jump_affect_expr::Tuple{Vector{Expr},Vararg{Vector{Expr}}}
         p_matrix::Array{Float64,2}
@@ -37,6 +39,7 @@ function maketype(name,
                   $(Expr(:kw,:g,g)),
                   $(Expr(:kw,:g_func,g_func)),
                   $(Expr(:kw,:jumps,jumps)),
+                  $(Expr(:kw,:regular_jumps,regular_jumps)),
                   $(Expr(:kw,:jump_rate_expr,jump_rate_expr)),
                   $(Expr(:kw,:jump_affect_expr,jump_affect_expr)),
                   $(Expr(:kw,:p_matrix,p_matrix)),
@@ -52,6 +55,7 @@ function maketype(name,
                       g,
                       g_func,
                       jumps,
+                      regular_jumps,
                       jump_rate_expr,
                       jump_affect_expr,
                       p_matrix,

--- a/src/reaction_network.jl
+++ b/src/reaction_network.jl
@@ -336,7 +336,7 @@ function get_jumps(reactions::Vector{ReactionStruct}, reactants::OrderedDict{Sym
         push!(reg_rates.args,:(internal_var___out[$idx]=$syntax_rate))
         foreach(r -> push!(reg_c.args,:(internal_var___dc[$(reactants[r]),$idx]=$(get_stoch_diff(reaction,r)))), reactant_set)
     end
-    reg_jumps = :(RegularJump((internal_var___out,internal_var___u,internal_var___p,t)->$rates,(internal_var___dc,internal_var___u,internal_var___p,t,internal_var___mark)->c,zeros($(length(reactants)),$(length(reactions)));constant_c=true))
+    reg_jumps = :(RegularJump((internal_var___out,internal_var___u,internal_var___p,t)->$reg_rates,(internal_var___dc,internal_var___u,internal_var___p,t,internal_var___mark)->$reg_c,zeros($(length(reactants)),$(length(reactions)));constant_c=true))
     return (Tuple(rates),Tuple(affects),jumps,reg_jumps)
 end
 

--- a/src/reaction_network.jl
+++ b/src/reaction_network.jl
@@ -92,8 +92,8 @@ function coordinate(name, ex::Expr, p, scale_noise)
     g = make_func(g_expr, reactants, parameters)
     p_matrix = zeros(length(reactants), length(reactions))
 
-    (jump_rate_expr, jump_affect_expr, jumps) = get_jumps(reactions, reactants,parameters)
-    regular_jumps = get_regular_jumps(jump_rate_expr, jump_affect_expr, p_matrix)
+    (jump_rate_expr, jump_affect_expr, jumps) = get_jumps(reactions, reactants, parameters)
+    regular_jumps = get_regular_jumps(jump_rate_expr, jump_affect_expr, p_matrix, reactants, parameters)
 
     f_rhs = [element.args[2] for element in f_expr]
     #symjac = Expr(:quote, calculate_jac(f_rhs, syms))
@@ -335,11 +335,12 @@ function get_jumps(reactions::Vector{ReactionStruct}, reactants::OrderedDict{Sym
     return (Tuple(rates),Tuple(affects),jumps)
 end
 
-function  get_regular_jumps(jump_rate_expr::Tuple{Any,Vararg{Any}}, jump_affect_expr::Tuple{Vector{Expr},Vararg{Vector{Expr}}},template_matrix::Array{Float64,2})
+#Generates a RegularJump corresponding to the reactions.
+function  get_regular_jumps(jump_rate_expr::Tuple{Any,Vararg{Any}}, jump_affect_expr::Tuple{Vector{Expr},Vararg{Vector{Expr}}},template_matrix::Array{Float64,2}, reactants::OrderedDict{Symbol,Int}, parameters::OrderedDict{Symbol,Int})
     rates = Expr(:block)
     c = Expr(:block)
     dc = :(zeros($(size(template_matrix)[1]),$(size(template_matrix)[2])))
-
+    foreach(r -> , jump_rate_expr)
     return :(RegularJump((out,u,p,t)->$rates,(dc,u,p,t,mark)->c,$dc;constant_c=true))
 end
 

--- a/src/reaction_network.jl
+++ b/src/reaction_network.jl
@@ -105,7 +105,7 @@ function coordinate(name, ex::Expr, p, scale_noise)
     f_funcs = [element.args[2] for element in f_expr]
     g_funcs = [element.args[2] for element in g_expr]
 
-    typeex,constructorex = maketype(name, f, f_funcs, f_symfuncs, g, g_funcs, jumps, Meta.quot(jump_rate_expr), Meta.quot(jump_affect_expr), p_matrix, syms; params=params, reactions=reactions)
+    typeex,constructorex = maketype(name, f, f_funcs, f_symfuncs, g, g_funcs, jumps, regular_jumps, Meta.quot(jump_rate_expr), Meta.quot(jump_affect_expr), p_matrix, syms; params=params, reactions=reactions)
 
     push!(exprs,typeex)
     push!(exprs,constructorex)

--- a/src/reaction_network.jl
+++ b/src/reaction_network.jl
@@ -93,7 +93,7 @@ function coordinate(name, ex::Expr, p, scale_noise)
     p_matrix = zeros(length(reactants), length(reactions))
 
     (jump_rate_expr, jump_affect_expr, jumps) = get_jumps(reactions, reactants,parameters)
-    regular_jumps = get_regular_jumps(jump_rate_expr, jump_affect_expr)
+    regular_jumps = get_regular_jumps(jump_rate_expr, jump_affect_expr, p_matrix)
 
     f_rhs = [element.args[2] for element in f_expr]
     #symjac = Expr(:quote, calculate_jac(f_rhs, syms))
@@ -335,8 +335,12 @@ function get_jumps(reactions::Vector{ReactionStruct}, reactants::OrderedDict{Sym
     return (Tuple(rates),Tuple(affects),jumps)
 end
 
-function  get_regular_jumps(jump_rate_expr::Tuple{Any,Vararg{Any}}, jump_affect_expr::Tuple{Vector{Expr},Vararg{Vector{Expr}}})
+function  get_regular_jumps(jump_rate_expr::Tuple{Any,Vararg{Any}}, jump_affect_expr::Tuple{Vector{Expr},Vararg{Vector{Expr}}},template_matrix::Array{Float64,2})
+    rates = Expr(:block)
+    c = Expr(:block)
+    dc = :(zeros($(size(template_matrix)[1]),$(size(template_matrix)[2])))
 
+    return :(RegularJump((out,u,p,t)->$rates,(dc,u,p,t,mark)->c,$dc;constant_c=true))
 end
 
 #Recursively traverses an expression and removes things like X^1, 1*X. Will not actually have any affect on the expression when used as a function, but will make it much easier to look at it for debugging, as well as if it is transformed to LaTeX code.

--- a/src/reaction_network.jl
+++ b/src/reaction_network.jl
@@ -93,6 +93,7 @@ function coordinate(name, ex::Expr, p, scale_noise)
     p_matrix = zeros(length(reactants), length(reactions))
 
     (jump_rate_expr, jump_affect_expr, jumps) = get_jumps(reactions, reactants,parameters)
+    regular_jumps = get_regular_jumps(jump_rate_expr, jump_affect_expr)
 
     f_rhs = [element.args[2] for element in f_expr]
     #symjac = Expr(:quote, calculate_jac(f_rhs, syms))
@@ -332,6 +333,10 @@ function get_jumps(reactions::Vector{ReactionStruct}, reactants::OrderedDict{Sym
         #end
     end
     return (Tuple(rates),Tuple(affects),jumps)
+end
+
+function  get_regular_jumps(jump_rate_expr::Tuple{Any,Vararg{Any}}, jump_affect_expr::Tuple{Vector{Expr},Vararg{Vector{Expr}}})
+
 end
 
 #Recursively traverses an expression and removes things like X^1, 1*X. Will not actually have any affect on the expression when used as a function, but will make it much easier to look at it for debugging, as well as if it is transformed to LaTeX code.

--- a/src/reaction_network.jl
+++ b/src/reaction_network.jl
@@ -333,8 +333,8 @@ function get_jumps(reactions::Vector{ReactionStruct}, reactants::OrderedDict{Sym
             push!(jumps.args[idx].args, :((internal_var___u,internal_var___p,t) -> $syntax_rate))
             push!(jumps.args[idx].args, :(integrator -> $(expr_arr_to_block(deepcopy(affects[idx])))))
         #end
-        push!(reg_rates,:(internal_var___out[$idx]=$syntax_rate))
-        foreach(r -> push!(reg_c,:(internal_var___dc[$(reactants[r]),$idx])=$(get_stoch_diff(reaction,r)))), reactant_set)
+        push!(reg_rates.args,:(internal_var___out[$idx]=$syntax_rate))
+        foreach(r -> push!(reg_c.args,:(internal_var___dc[$(reactants[r]),$idx]=$(get_stoch_diff(reaction,r)))), reactant_set)
     end
     reg_jumps = :(RegularJump((internal_var___out,internal_var___u,internal_var___p,t)->$rates,(internal_var___dc,internal_var___u,internal_var___p,t,internal_var___mark)->c,zeros($(length(reactants)),$(length(reactions)));constant_c=true))
     return (Tuple(rates),Tuple(affects),jumps,reg_jumps)

--- a/src/reaction_network.jl
+++ b/src/reaction_network.jl
@@ -340,14 +340,6 @@ function get_jumps(reactions::Vector{ReactionStruct}, reactants::OrderedDict{Sym
     return (Tuple(rates),Tuple(affects),jumps,reg_jumps)
 end
 
-#Generates a RegularJump corresponding to the reactions.
-function  get_regular_jumps(jump_rate_expr::Tuple{Any,Vararg{Any}}, jump_affect_expr::Tuple{Vector{Expr},Vararg{Vector{Expr}}},template_matrix::Array{Float64,2}, reactants::OrderedDict{Symbol,Int}, parameters::OrderedDict{Symbol,Int})
-    rates = Expr(:block)
-    c = Expr(:block)
-    dc = :(zeros($(size(template_matrix)[1]),$(size(template_matrix)[2])))
-    return :(RegularJump((out,u,p,t)->$rates,(dc,u,p,t,mark)->c,$dc;constant_c=true))
-end
-
 #Recursively traverses an expression and removes things like X^1, 1*X. Will not actually have any affect on the expression when used as a function, but will make it much easier to look at it for debugging, as well as if it is transformed to LaTeX code.
 function recursive_clean!(expr::Any)
     (expr == :no___noise___scaling) && (return 1)


### PR DESCRIPTION
A `RegularJump` structure is now calculated (but not yet used for any problem creation).

There is a new field in the `AbstractReactionNetwork` type, `regular_jumps` which contains a `RegularJump` which can be used for SSA.