### PR TITLE
Function overload

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,5 @@
 julia 0.6
-DiffEqJump 1.0.0
+DiffEqJump 4.2.0
 DiffEqBase 3.4.0
 Compat 0.17.0
 DataStructures 0.4.6

--- a/src/DiffEqBiological.jl
+++ b/src/DiffEqBiological.jl
@@ -17,7 +17,7 @@ include("maketype.jl")
 include("problem.jl")
 
 export @reaction_network, @reaction_func
-export ODEProblem, SDEProblem, JumpProblem, SteadyStateProblem
+export SDEProblem, JumpProblem, SteadyStateProblem
 
 Reaction(args...) = error("""
  The old Reaction DSL is deprecated for a new

--- a/src/problem.jl
+++ b/src/problem.jl
@@ -1,10 +1,6 @@
-### ODEProblem ###
-DiffEqBase.ODEProblem(rn::AbstractReactionNetwork, args...; kwargs...) =
-    ODEProblem(rn.f, args...; kwargs...)
-
 ### SDEProblem ###
-DiffEqBase.SDEProblem(rn::AbstractReactionNetwork, args...; kwargs...) =
-    SDEProblem(rn.f,rn.g, args...;noise_rate_prototype=rn.p_matrix, kwargs...)
+DiffEqBase.SDEProblem(rn::AbstractReactionNetwork, u0::Union{AbstractArray, Number}, args...; kwargs...) =
+    SDEProblem(rn, rn.g, u0, args...;noise_rate_prototype=rn.p_matrix, kwargs...)
 
 ### JumpProblem ###
 function DiffEqJump.JumpProblem(prob,aggregator::Direct,rn::AbstractReactionNetwork; kwargs...)

--- a/src/reaction_network.jl
+++ b/src/reaction_network.jl
@@ -110,6 +110,14 @@ function coordinate(name, ex::Expr, p, scale_noise)
     push!(exprs,typeex)
     push!(exprs,constructorex)
 
+    ## Overload the type so that it can act as a function.
+    overloadex = :(((f::$name))(du, u, p, t::Number) = f.f(du, u, p, t)) |> esc
+    push!(exprs,overloadex)
+
+    ## Add a method which allocates the `du` and returns it instead of being inplace
+    overloadex = :(((f::$name))(u,p,t::Number) = (du=similar(u); f(du,u,p,t); du)) |> esc
+    push!(exprs,overloadex)
+
     # export type constructor
     def_const_ex = :(($name)()) |> esc
     push!(exprs,def_const_ex)

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,3 +1,3 @@
 OrdinaryDiffEq
 StochasticDiffEq
-SteadyStateDiffEq
+SteadyStateDiffEq 0.4.0

--- a/test/solver_test.jl
+++ b/test/solver_test.jl
@@ -41,3 +41,5 @@ sol1 = solve(prob1,Tsit5())
 prob2 = ODEProblem(equi_model,[100.],(0.,200.))
 sol2 = solve(prob2,Tsit5())
 @test 1.5*sol1[end][1] < sol2[end][1]
+
+@test sol1.prob.f isa AbstractReactionNetwork


### PR DESCRIPTION
Overload the reaction network type with the generated deterministic function  

```julia
(f::myReactionTypeName)(du, u, p, t) = f.f(du,u,p,t)
```

This mirrors what has been done in ParameterizedFunctions.jl and allows the full reaction network object to be passed along in the problems and solutions. 

This automatically allows the plot recipe to use the variable names. Closes #18.

I also updated the DiffEqJump requirement since this was causing an issue for me when testing.   