### PR TITLE
WIP: generate dependency graph for reaction networks

### DIFF
--- a/src/massaction_jump_utils.jl
+++ b/src/massaction_jump_utils.jl
@@ -43,7 +43,9 @@ function get_net_stoich(rs, specmap)
 
     net_stoich = Vector{Pair{Int,Int}}()
     for stoich_map in sort(collect(nsdict))
-        push!(net_stoich, stoich_map)
+        if stoich_map[2] != zero(Int)
+            push!(net_stoich, stoich_map)
+        end
     end
 
     net_stoich

--- a/src/problem.jl
+++ b/src/problem.jl
@@ -17,7 +17,14 @@ function DiffEqJump.JumpProblem(prob,aggregator,rn::AbstractReactionNetwork; kwa
     # get a JumpSet of the possible jumps
     jset = network_to_jumpset(rn, spec_to_idx, param_to_idx, prob.p)
 
-    JumpProblem(prob, aggregator, jset; kwargs...)
+    # # construct dependency graph if needed by aggregator
+    if needs_depgraph(aggregator)
+        dep_graph = depgraph_from_network(rn, spec_to_idx, jset)
+    else
+        dep_graph = nothing
+    end
+
+    JumpProblem(prob, aggregator, jset; dep_graph=dep_graph, kwargs...)
 end
 
 ### SteadyStateProblem ###

--- a/test/mass_act_jump_tests.jl
+++ b/test/mass_act_jump_tests.jl
@@ -24,7 +24,7 @@ function execute_test(u0, tf, rates, rs, Nsims, expected_avg, idx, test_name)
         
         if dotestmean
             if doprintmeans
-                println(test_name, "method = ", typeof(method), ", mean = ", avg_val, ", act_mean = ", expected_avg)
+                println(test_name, ", method = ", typeof(method), ", mean = ", avg_val, ", act_mean = ", expected_avg)
             end
             @test abs(avg_val - expected_avg) < reltol * expected_avg
         end
@@ -59,11 +59,28 @@ rs = @reaction_network ptype begin
 end k1 k2 k3 k4 k5 k6
 Nsims        = 8000
 tf           = 1000.0
-u0           = [1,0,0,0]
+u0           = [1,0,0,0]  
 expected_avg = 5.926553750000000e+02
 rates = [.5, (20*log(2.)/120.), (log(2.)/120.), (log(2.)/600.), .025, 1.]
 execute_test(u0, tf, rates, rs, Nsims, expected_avg, 3, "DNA test")
 
+
+# DNA repression model, mix of jump types
+rs = @reaction_network ptype begin
+    k1*DNA, 0 --> mRNA
+    k2*mRNA, 0 --> P
+    k3, mRNA --> 0
+    k4, P --> 0
+    k5, DNA + P --> DNAR
+    k6, DNAR --> DNA + P
+end k1 k2 k3 k4 k5 k6
+Nsims        = 8000
+tf           = 1000.0
+u0           = [0,0,0,0]
+u0[findfirst(rs.syms, :DNA)] = 1
+expected_avg = 5.926553750000000e+02
+rates = [.5, (20*log(2.)/120.), (log(2.)/120.), (log(2.)/600.), .025, 1.]
+execute_test(u0, tf, rates, rs, Nsims, expected_avg, findfirst(rs.syms, :P), "DNA mixed jump test")
 
 # simple constant production with degratation
 rs = @reaction_network pdtype begin


### PR DESCRIPTION
This PR should now allow the automatic generation of dependency graphs for networks with mixes of mass action and constant rate jumps. The graph is then passed into any jump problem aggregators that require a dependency graph.

I think this is actually ready to go, but it doesn't make sense to merge until my current `DiffEqJump` PR gets merged (which adds the sorting direct method SSA and a `dep_graph` named parameter for `JumpProblem`s). I'll leave it as WIP until that gets merged.

