### PR TITLE
Depricate default

### DIFF
--- a/src/reaction_network.jl
+++ b/src/reaction_network.jl
@@ -59,9 +59,9 @@ macro reaction_network(name, scale_noise, ex::Expr, p...)
     coordinate(name, MacroTools.striplines(ex), p, scale_noise)
 end
 
-#Used to give a warning if someone uses the old macro.
-macro reaction_network(ex::Expr)
-    error("The Reaction Network DSL have been deprecated in favor for a new one. With only slight modification old code can be made to work with the new DSL. In addition the new one provides lots of additional functionality. Please view the documentation for more information.")
+#If no type name is given, creates a network with a default name.
+macro reaction_network(ex::Expr, p...)
+    coordinate(:reaction_network, MacroTools.striplines(ex), p, :no___noise___scaling)
 end
 
 #Declare various arrow types symbols used for the empty set (also 0).

--- a/test/make_model_test.jl
+++ b/test/make_model_test.jl
@@ -1,4 +1,4 @@
-using DiffEqBiological, Test
+using DiffEqBiological, Test, DiffEqBase
 
 network1 = @reaction_network rn begin
     2.0, X + Y --> XY

--- a/test/make_model_test.jl
+++ b/test/make_model_test.jl
@@ -78,3 +78,17 @@ for i = 1:100
     @test network4.jumps[2].rate(u,p,t) == network5.jumps[2].rate(u,p,t)
     @test network4.jumps[3].rate(u,p,t) == network5.jumps[3].rate(u,p,t)
 end
+
+network6 = @reaction_network begin
+    p2, X + Y --> XY
+    p1, XY ← X + Y
+    (1,X), Z ↔ Z1 + Z2
+end p1 p2
+
+@test length(network6.f_func) == 6
+@test length(network6.g_func) == 24
+@test size(network6.p_matrix) == (6,4)
+@test length(network6.params) == 2
+@test length(network6.syms) == 6
+@test typeof(network6) <: DiffEqBase.AbstractReactionNetwork
+@test typeof(network6) == reaction_network


### PR DESCRIPTION
Currently declaring a reaction network like
```julia
model = @reaction_network begin
    1.0, X --> Y
end
```
gives a deprecation warning for the old DSL. Eventually this should be changed to create a reaction network with some default type. This PR does just that and can be merged when we think the time is right.