### PR TITLE
fix vector initialization for 1.0

### DIFF
--- a/src/massaction_jump_utils.jl
+++ b/src/massaction_jump_utils.jl
@@ -163,7 +163,7 @@ function depgraph_from_network(rn, specmap, jset)
     end
 
     # convert to Vectors of Vectors
-    dep_graph = Vector{Vector{Int}}(numrxs)
+    dep_graph = Vector{Vector{Int}}(undef,numrxs)
     for jidx in 1:numrxs
         dep_graph[jidx] = [dep for dep in dep_sets[jidx]]
     end

--- a/test/mass_act_jump_tests.jl
+++ b/test/mass_act_jump_tests.jl
@@ -3,7 +3,7 @@ using DiffEqBiological, DiffEqJump, DiffEqBase, Test, Statistics
 dotestmean   = true
 doprintmeans = false
 reltol       = .01          # required test accuracy
-algs      = (Direct(),)# SortingDirect())
+algs      = (Direct(),SortingDirect())
 
 # run the given number of SSAs and return the mean
 function runSSAs(jump_prob, Nsims, idx)


### PR DESCRIPTION
Updating mass action dependency graph initialization for 1.0. Also re-enabling SortingDirect method tests (which test dependency graph generation within DiffEqBiological).