### PR TITLE
pass SSAs species to dependent reaction maps if needed

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,5 @@
 julia 1.0
-DiffEqJump 4.2.0
+DiffEqJump 5.6.0
 DiffEqBase 3.11.0
 Compat 0.17.0
 DataStructures 0.8.1

--- a/src/massaction_jump_utils.jl
+++ b/src/massaction_jump_utils.jl
@@ -125,8 +125,7 @@ function jump_to_dep_specs_map(rn, specmap, rxidxs_jidxs)
     jtos_vec = Vector{Vector{valtype(specmap)}}(undef, numrxs)
     for rx in 1:numrxs
         jidx = rxidxs_jidxs[rx]
-        jtos_vec[jidx] = [specmap[specsym] for specsym in rn.reactions[rx].dependants]
-        sort!(jtos_vec[jidx])
+        jtos_vec[jidx] = sort!( [specmap[specsym] for specsym in rn.reactions[rx].dependants] )
     end
 
     jtos_vec

--- a/src/massaction_jump_utils.jl
+++ b/src/massaction_jump_utils.jl
@@ -121,11 +121,11 @@ function jump_to_dep_specs_map(rn, specmap, rxidxs_jidxs)
     numrxs  = length(rn.reactions)
     numspec = length(specmap)
 
-    # map from a jump to species that depend on it
+    # map from a jump to vector of species that depend on it
     jtos_vec = Vector{Vector{valtype(specmap)}}(undef, numrxs)
     for rx in 1:numrxs
-        jidx = rxidxs_jidxs[rx]
-        jtos_vec[jidx] = sort!( [specmap[specsym] for specsym in rn.reactions[rx].dependants] )
+        jidx           = rxidxs_jidxs[rx]
+        jtos_vec[jidx] = sort!( [ns.first for ns in get_net_stoich(rn.reactions[rx], specmap)] )
     end
 
     jtos_vec

--- a/src/massaction_jump_utils.jl
+++ b/src/massaction_jump_utils.jl
@@ -116,9 +116,24 @@ function rxidxs_to_jidxs_map(rn, num_majumps)
     rxi_to_ji
 end
 
+# map from jump to vector of species it changes
+function jump_to_dep_specs_map(rn, specmap, rxidxs_jidxs)
+    numrxs  = length(rn.reactions)
+    numspec = length(specmap)
+
+    # map from a jump to species that depend on it
+    jtos_vec = Vector{Vector{valtype(specmap)}}(undef, numrxs)
+    for rx in 1:numrxs
+        jidx = rxidxs_jidxs[rx]
+        jtos_vec[jidx] = [specmap[specsym] for specsym in rn.reactions[rx].dependants]
+        sort!(jtos_vec[jidx])
+    end
+
+    jtos_vec
+end
+
 # map from species to Set of jumps depending on that species
 function spec_to_dep_jumps_map(rn, specmap, rxidxs_to_jidxs)
-
     numrxs  = length(rn.reactions)
     numspec = length(specmap)
 

--- a/src/problem.jl
+++ b/src/problem.jl
@@ -22,7 +22,7 @@ function DiffEqJump.JumpProblem(prob,aggregator,rn::DiffEqBase.AbstractReactionN
         rxidxs_to_jidxs   = rxidxs_to_jidxs_map(rn, get_num_majumps(jset))
         spec_to_jumps_set = spec_to_dep_jumps_map(rn, spec_to_idx, rxidxs_to_jidxs)
         spec_to_jumps_vec = [sort!(collect(specset)) for specset in spec_to_jumps_set]
-        jump_to_specs_vec  = jump_to_dep_specs_map(rn, spec_to_idx, rxidxs_jidxs)
+        jump_to_specs_vec = jump_to_dep_specs_map(rn, spec_to_idx, rxidxs_to_jidxs)
     else
         rxidxs_to_jidxs   = nothing
         spec_to_jumps_set = nothing

--- a/src/problem.jl
+++ b/src/problem.jl
@@ -17,14 +17,25 @@ function DiffEqJump.JumpProblem(prob,aggregator,rn::DiffEqBase.AbstractReactionN
     # get a JumpSet of the possible jumps
     jset = network_to_jumpset(rn, spec_to_idx, param_to_idx, prob.p)
 
-    # # construct dependency graph if needed by aggregator
+    # construct map from species index to indices of reactions that depend on it
+    if needs_vartojumps_map(aggregator) || needs_depgraph(aggregator)
+        rxidxs_to_jidxs   = rxidxs_to_jidxs_map(rn, get_num_majumps(jset))
+        spec_to_dep_jumps = spec_to_dep_jumps_map(rn, spec_to_idx, rxidxs_to_jidxs)
+    else
+        rxidxs_to_jidxs   = nothing
+        spec_to_dep_jumps = nothing
+    end
+
+    # construct reaction dependency graph
     if needs_depgraph(aggregator)
-        dep_graph = depgraph_from_network(rn, spec_to_idx, jset)
+        dep_graph = depgraph_from_network(rn, spec_to_idx, jset, rxidxs_to_jidxs, spec_to_dep_jumps)
     else
         dep_graph = nothing
     end
 
-    JumpProblem(prob, aggregator, jset; dep_graph=dep_graph, kwargs...)
+    JumpProblem(prob, aggregator, jset; dep_graph=dep_graph,
+                                        spec_to_dep_jumps=spec_to_dep_jumps,
+                                        kwargs...)
 end
 
 ### SteadyStateProblem ###

--- a/src/problem.jl
+++ b/src/problem.jl
@@ -34,7 +34,7 @@ function DiffEqJump.JumpProblem(prob,aggregator,rn::DiffEqBase.AbstractReactionN
     end
 
     JumpProblem(prob, aggregator, jset; dep_graph=dep_graph,
-                                        spec_to_dep_jumps=spec_to_dep_jumps,
+                                        varstojumps_map=spec_to_dep_jumps,
                                         kwargs...)
 end
 

--- a/src/problem.jl
+++ b/src/problem.jl
@@ -38,7 +38,7 @@ function DiffEqJump.JumpProblem(prob,aggregator,rn::DiffEqBase.AbstractReactionN
     end
 
     JumpProblem(prob, aggregator, jset; dep_graph=dep_graph,
-                                        varstojumps_map=spec_to_jumps_vec,
+                                        vartojumps_map=spec_to_jumps_vec,
                                         jumptovars_map=jump_to_specs_vec,
                                         kwargs...)
 end

--- a/src/problem.jl
+++ b/src/problem.jl
@@ -20,21 +20,26 @@ function DiffEqJump.JumpProblem(prob,aggregator,rn::DiffEqBase.AbstractReactionN
     # construct map from species index to indices of reactions that depend on it
     if needs_vartojumps_map(aggregator) || needs_depgraph(aggregator)
         rxidxs_to_jidxs   = rxidxs_to_jidxs_map(rn, get_num_majumps(jset))
-        spec_to_dep_jumps = spec_to_dep_jumps_map(rn, spec_to_idx, rxidxs_to_jidxs)
+        spec_to_jumps_set = spec_to_dep_jumps_map(rn, spec_to_idx, rxidxs_to_jidxs)
+        spec_to_jumps_vec = [sort!(collect(specset)) for specset in spec_to_jumps_set]
+        jump_to_specs_vec  = jump_to_dep_specs_map(rn, spec_to_idx, rxidxs_jidxs)
     else
         rxidxs_to_jidxs   = nothing
-        spec_to_dep_jumps = nothing
+        spec_to_jumps_set = nothing
+        spec_to_jumps_vec = nothing
+        jump_to_specs_vec = nothing
     end
 
     # construct reaction dependency graph
     if needs_depgraph(aggregator)
-        dep_graph = depgraph_from_network(rn, spec_to_idx, jset, rxidxs_to_jidxs, spec_to_dep_jumps)
+        dep_graph = depgraph_from_network(rn, spec_to_idx, jset, rxidxs_to_jidxs, spec_to_jumps_set)
     else
         dep_graph = nothing
     end
 
     JumpProblem(prob, aggregator, jset; dep_graph=dep_graph,
-                                        varstojumps_map=spec_to_dep_jumps,
+                                        varstojumps_map=spec_to_jumps_vec,
+                                        jumptovars_map=jump_to_specs_vec,
                                         kwargs...)
 end
 


### PR DESCRIPTION
This should only be merged after my DiffEqJump RSSA PR, as it relies on a function to query if SSAs need dependency maps from jumps to species (and vice-versa). It won't pass integration checks until it can use that PR.

Some SSAs I'm working on require different dependency info (namely species to dependent reaction maps). This sets up DiffEqBiological to pass the required info.