### PR TITLE
(WIP -- for testing) simplified reaction_network that gives faster parsing

### DIFF
--- a/src/maketype.jl
+++ b/src/maketype.jl
@@ -70,3 +70,32 @@ function maketype(name,
     # Make the type instance using the default constructor
     typeex,constructorex
 end
+
+# short version
+function maketype(name,
+    syms;
+    params = Symbol[],
+    reactions=Vector{ReactionStruct}(undef,0)
+    )
+
+typeex = :(mutable struct $name <: DiffEqBase.AbstractReactionNetwork
+syms::Vector{Symbol}
+params::Vector{Symbol}
+reactions::Vector{ReactionStruct}
+end)
+# Make the default constructor
+constructorex = :($(name)(;
+    $(Expr(:kw,:syms,syms)),
+    $(Expr(:kw,:params,params)),
+    $(Expr(:kw,:reactions,reactions))) =
+    $(name)(
+        syms,
+        params,
+        reactions
+        )) |> esc
+
+        #f_funcs,symfuncs,pfuncs,syms,symjac) |> esc
+
+# Make the type instance using the default constructor
+typeex,constructorex
+end

--- a/src/problem.jl
+++ b/src/problem.jl
@@ -4,7 +4,7 @@ DiffEqBase.SDEProblem(rn::DiffEqBase.AbstractReactionNetwork, u0::Union{Abstract
 
 ### JumpProblem ###
 function DiffEqJump.JumpProblem(prob,aggregator,rn::DiffEqBase.AbstractReactionNetwork; kwargs...)
-    if typeof(prob)<:DiscreteProblem && any(x->typeof(x) <: VariableRateJump, rn.jumps)
+    if typeof(prob)<:DiscreteProblem && in(:jump,fieldnames(typeof(rn))) && any(x->typeof(x) <: VariableRateJump, rn.jumps)
         error("When using time dependant reaction rates a DiscreteProblem should not be used (try an ODEProblem). Also, use a continious solver.")
     end
 

--- a/src/reaction_network.jl
+++ b/src/reaction_network.jl
@@ -83,38 +83,39 @@ function coordinate(name, ex::Expr, p, scale_noise)
 
     update_reaction_info(reactions,syms)
 
-    f_expr = get_f(reactions, reactants)
-    f = make_func(f_expr, reactants, parameters)
+    # f_expr = get_f(reactions, reactants)
+    # f = make_func(f_expr, reactants, parameters)
 
-    g_expr = get_g(reactions, reactants, scale_noise)
-    g = make_func(g_expr, reactants, parameters)
-    p_matrix = zeros(length(reactants), length(reactions))
+    # g_expr = get_g(reactions, reactants, scale_noise)
+    # g = make_func(g_expr, reactants, parameters)
+    # p_matrix = zeros(length(reactants), length(reactions))
 
-    (jump_rate_expr, jump_affect_expr, jumps, regular_jumps) = get_jumps(reactions, reactants, parameters)
+    # (jump_rate_expr, jump_affect_expr, jumps, regular_jumps) = get_jumps(reactions, reactants, parameters)
 
-    f_rhs = [element.args[2] for element in f_expr]
-    symjac = Expr(:quote, calculate_jac(deepcopy(f_rhs), syms))
-    f_symfuncs = hcat([SymEngine.Basic(f) for f in f_rhs])
+    # f_rhs = [element.args[2] for element in f_expr]
+    # symjac = Expr(:quote, calculate_jac(deepcopy(f_rhs), syms))
+    # f_symfuncs = hcat([SymEngine.Basic(f) for f in f_rhs])
 
-    # Build the type
+    # # Build the type
     exprs = Vector{Expr}(undef,0)
 
-    ## only get the right-hand-side of the equations.
-    f_funcs = [element.args[2] for element in f_expr]
-    g_funcs = [element.args[2] for element in g_expr]
+    # ## only get the right-hand-side of the equations.
+    # f_funcs = [element.args[2] for element in f_expr]
+    # g_funcs = [element.args[2] for element in g_expr]
 
-    typeex,constructorex = maketype(name, f, f_funcs, f_symfuncs, g, g_funcs, jumps, regular_jumps, Meta.quot(jump_rate_expr), Meta.quot(jump_affect_expr), p_matrix, syms; params=params, reactions=reactions, symjac=symjac)
+    # typeex,constructorex = maketype(name, f, f_funcs, f_symfuncs, g, g_funcs, jumps, regular_jumps, Meta.quot(jump_rate_expr), Meta.quot(jump_affect_expr), p_matrix, syms; params=params, reactions=reactions, symjac=symjac)
+    typeex,constructorex = maketype(name, syms; params=params, reactions=reactions)
 
     push!(exprs,typeex)
     push!(exprs,constructorex)
 
-    ## Overload the type so that it can act as a function.
-    overloadex = :(((f::$name))(du, u, p, t::Number) = f.f(du, u, p, t)) |> esc
-    push!(exprs,overloadex)
+    # ## Overload the type so that it can act as a function.
+    # overloadex = :(((f::$name))(du, u, p, t::Number) = f.f(du, u, p, t)) |> esc
+    # push!(exprs,overloadex)
 
-    ## Add a method which allocates the `du` and returns it instead of being inplace
-    overloadex = :(((f::$name))(u,p,t::Number) = (du=similar(u); f(du,u,p,t); du)) |> esc
-    push!(exprs,overloadex)
+    # ## Add a method which allocates the `du` and returns it instead of being inplace
+    # overloadex = :(((f::$name))(u,p,t::Number) = (du=similar(u); f(du,u,p,t); du)) |> esc
+    # push!(exprs,overloadex)
 
     # export type constructor
     def_const_ex = :(($name)()) |> esc


### PR DESCRIPTION
For testing the large network performance of the `reaction_network` macro when stripping out the creation of most functions. This is just to illustrate the changes I mentioned in [68](https://github.com/JuliaDiffEq/DiffEqBiological.jl/issues/68) for anyone that is interested.