### PR TITLE
add reexport of DiffEqBase

### DIFF
--- a/src/DiffEqBiological.jl
+++ b/src/DiffEqBiological.jl
@@ -9,7 +9,7 @@ using SymEngine
 using MacroTools
 using DataStructures
 using Parameters
-@reexport using DiffEqJump
+@reexport using DiffEqBase, DiffEqJump
 
 using Compat
 


### PR DESCRIPTION
```
rn = @reaction_network rType begin
        (kB, kD), X + Y ↔ XY
        end kB kD
```
gives 
```
ERROR: UndefVarError: ODEFunction not defined
```
due to `DiffEqBase` not being reexported.