### PR TITLE
kwargs to disable generation of jacobian and symfuncs

### DIFF
--- a/src/maketype.jl
+++ b/src/maketype.jl
@@ -122,10 +122,10 @@ function gentypefun_exprs(name; esc_exprs=true, gen_inplace=true, gen_outofplace
     exprs
 end
 
-function addodes!(rn::DiffEqBase.AbstractReactionNetwork)
+function addodes!(rn::DiffEqBase.AbstractReactionNetwork; kwargs...)
     @unpack reactions, syms_to_ints, params_to_ints, syms = rn
 
-    (f_expr, f, f_rhs, symjac, f_symfuncs) = genode_exprs(reactions, syms_to_ints, params_to_ints, syms)
+    (f_expr, f, f_rhs, symjac, f_symfuncs) = genode_exprs(reactions, syms_to_ints, params_to_ints, syms; kwargs...)
     rn.f          = eval(f)
     rn.f_func     = f_rhs
     rn.symjac     = eval(symjac)

--- a/src/reaction_network.jl
+++ b/src/reaction_network.jl
@@ -150,12 +150,13 @@ function gensde_exprs(reactions, reactants, parameters, scale_noise)
 end
 
 # ODE expressions
-function genode_exprs(reactions, reactants, parameters, syms)
+function genode_exprs(reactions, reactants, parameters, syms; build_symjac=true, 
+                                                              build_symfuncs=true)
     f_expr     = get_f(reactions, reactants)
     f          = make_func(f_expr, reactants, parameters)
     f_rhs      = [element.args[2] for element in f_expr]
-    symjac     = Expr(:quote, calculate_jac(deepcopy(f_rhs), syms))
-    f_symfuncs = hcat([SymEngine.Basic(f) for f in f_rhs])
+    symjac     = build_symjac ? Expr(:quote, calculate_jac(deepcopy(f_rhs), syms)) : nothing
+    f_symfuncs = build_symfuncs ? hcat([SymEngine.Basic(f) for f in f_rhs]) : nothing
 
     (f_expr,f,f_rhs,symjac,f_symfuncs)
 end


### PR DESCRIPTION
Add kwargs to `addodes!` to disable the construction of the symbolic Jacobian and `SymEngine` functions. 

This would only apply for the `min_reaction_network`.

Disabling Jacobians speeds up the macro enough that within seconds the ODEs for a 1200 species, 25,000 reaction network can be constructed and returned.