### PR TITLE
abs the sqrt in the CLE

### DIFF
--- a/src/reaction_network.jl
+++ b/src/reaction_network.jl
@@ -341,7 +341,7 @@ function get_g(reactions::Vector{ReactionStruct}, reactants::OrderedDict{Symbol,
     g = Vector{Expr}(undef,length(reactions)*length(reactants))
     idx = 0
     for reactant in keys(reactants), i = 1:length(reactions)
-            g[idx += 1] = recursive_clean!(:(internal_var___du[$(reactants[reactant]),$i] = $scale_noise * $(get_stoch_diff(reactions[i],reactant)) * sqrt($(deepcopy(reactions[i].rate_DE)))))
+            g[idx += 1] = recursive_clean!(:(internal_var___du[$(reactants[reactant]),$i] = $scale_noise * $(get_stoch_diff(reactions[i],reactant)) * sqrt(abs($(deepcopy(reactions[i].rate_DE))))))
     end
     return g
 end


### PR DESCRIPTION
This approximation is from Higham

https://strathprints.strath.ac.uk/13549/1/siamssa.pdf

If a value ever goes negative it's unphysical, but this can make it so you can finish the step. Then rootfinding can occur to approximate the zero. This would fix the domain errors that @TorkelE had and allow domain callbacks to work.