### PR TITLE
separate out network query functions

### DIFF
--- a/src/DiffEqBiological.jl
+++ b/src/DiffEqBiological.jl
@@ -15,11 +15,20 @@ using Compat
 
 include("reaction_network.jl")
 include("maketype.jl")
+include("network_properties.jl")
 include("massaction_jump_utils.jl")
 include("problem.jl")
 
+# reaction network macro
 export @reaction_network, @reaction_func, @min_reaction_network
+
+# functions to query network properties
+export speciesmap, paramsmap, get_substrate_stoich, get_net_stoich
+
+# functions to add mathematical equations to the network
 export addodes!, addsdes!, addjumps!
+
+# problems that can be solved from the network
 export ODEProblem, SDEProblem, DiscreteProblem, JumpProblem, SteadyStateProblem
 
 end # module

--- a/src/network_properties.jl
+++ b/src/network_properties.jl
@@ -1,0 +1,49 @@
+""" 
+Functions for querying network properties.
+"""
+
+"""
+Return a Dictionary mapping from species symbol to species index.
+"""
+function speciesmap(network)
+    network.syms_to_ints
+end
+
+"""
+Return a Dictionary mapping from parameter symbol to parameter index.
+"""
+function paramsmap(network)
+    network.params_to_ints
+end
+
+"""
+Return a Vector of pairs, mapping ids of species that serve as substrates 
+in the reaction to the corresponding stoichiometric coefficiant as a substrate.
+"""
+function get_substrate_stoich(rs::ReactionStruct, specmap)
+    reactant_stoich = [specmap[s.reactant] => s.stoichiometry for s in rs.substrates]
+    sort!(reactant_stoich)
+    reactant_stoich
+end
+
+"""
+Return a Vector of pairs, mapping ids of species that participate in the 
+reaction to the net stoichiometric coefficiant of the species (i.e. net change
+in the species due to the reaction).
+"""
+function get_net_stoich(rs::ReactionStruct, specmap)
+    nsdict = Dict{Int,Int}(specmap[s.reactant] => -s.stoichiometry for s in rs.substrates)
+
+    for prod in rs.products
+        pidx = specmap[prod.reactant]
+        nsdict[pidx] = haskey(nsdict, pidx) ? nsdict[pidx] + prod.stoichiometry : prod.stoichiometry
+    end
+
+    net_stoich = Vector{Pair{Int,Int}}()
+    for stoich_map in sort(collect(nsdict))
+        (stoich_map[2] != zero(Int)) && push!(net_stoich, stoich_map)
+    end
+
+    net_stoich
+end
+


### PR DESCRIPTION
This separates out functions that we should expose for querying network properties, and also cleans up the jump creation functions a bit to avoid redundancies (since we've pre-calculated stuff in the reaction_network now that wasn't there before).

My plan is to start adding more (exported) network query functions to `network_properties.jl` as time goes on. (Things that would be useful for exporting to other packages, creating graphs, and more generally analyzing network properties.)