### PR TITLE
Split +

### DIFF
--- a/src/reaction_network.jl
+++ b/src/reaction_network.jl
@@ -359,7 +359,7 @@ function get_stoch_diff(reaction::ReactionStruct, reactant::Symbol)
 end
 
 function splitplus!(ex)
-  dosplit = ex.head == :(=) && ex.args[2].head == :call && ex.args[2].args[1] == :(+)
+  dosplit = ex.head == :(=) && ex.args[2] isa Expr && ex.args[2].head == :call && ex.args[2].args[1] == :(+)
   if dosplit
     summands = ex.args[2].args[2:end]
     ex.args[2] = foldl((x,y)->(:(($x + $y))), summands)

--- a/src/reaction_network.jl
+++ b/src/reaction_network.jl
@@ -154,9 +154,6 @@ function genode_exprs(reactions, reactants, parameters, syms; build_jac=true,
                                                               build_symfuncs=true)
     f_expr                = get_f(reactions, reactants)
     f                     = make_func(f_expr, reactants, parameters)
-    open("test","w") do io
-        println(io, f)
-    end
     f_rhs                 = [element.args[2] for element in f_expr]
     symjac, jac, paramjac = build_jac ? get_jacs(f_rhs, syms, reactants, parameters) : (nothing,nothing,nothing)
     f_symfuncs            = build_symfuncs ? hcat([SymEngine.Basic(f) for f in f_rhs]) : nothing


### PR DESCRIPTION
lololololololol

Okay, real explanation. If you add a ton of things in one line, you get +(...) which makes a giant tuple and then loops through to do the add. But that tuple is large enough that it leaves cache and allocates, since in our example from https://github.com/JuliaDiffEq/OrdinaryDiffEq.jl/issues/664 we have like 255 adds per expression. This adds parenthesis so that way all + operations are pairwise. We might be able to optimize a bit by making it like 8-wise, but on our example it's still 100x faster.