### PR TITLE
fix +0s and -1* and add inbounds for jumps

### DIFF
--- a/src/maketype.jl
+++ b/src/maketype.jl
@@ -13,11 +13,10 @@ function maketype(abstracttype,
                   syms,
                   scale_noise;
                   params = Symbol[],
-                  pfuncs=Vector{Expr}(undef,0),
                   jac = nothing,
                   paramjac = nothing,
                   jac_prototype = nothing,
-                  symjac=Matrix{Expr}(undef,0,0),
+                  symjac=Matrix{Union{Expr,Symbol,Number}}(undef,0,0),
                   reactions=Vector{ReactionStruct}(undef,0),
                   syms_to_ints = OrderedDict{Symbol,Int}(),
                   params_to_ints = OrderedDict{Symbol,Int}(),
@@ -27,13 +26,13 @@ function maketype(abstracttype,
 
     typeex = :(mutable struct $name <: $(abstracttype)
         f::Union{Function,Nothing}
-        f_func::Union{Vector{Expr},Nothing}
+        f_func::Union{Vector{Union{Expr,Symbol,Number}},Nothing}
         f_symfuncs::Union{Matrix{SymEngine.Basic},Nothing}
         g::Union{Function,Nothing}
-        g_func::Union{Vector{Any},Nothing}
+        g_func::Union{Vector{Union{Expr,Symbol,Number}},Nothing}
         jumps::Union{Tuple{Vararg{DiffEqJump.AbstractJump}},Nothing}
         regular_jumps::Union{RegularJump,Nothing}
-        jump_rate_expr::Union{Tuple{Any,Vararg{Any}},Nothing}
+        jump_rate_expr::Union{Tuple{Union{Expr,Symbol,Number},Vararg{Union{Expr,Symbol,Number}}},Nothing}
         jump_affect_expr::Union{Tuple{Vector{Expr},Vararg{Vector{Expr}}},Nothing}
         p_matrix::Union{Array{Float64,2},Nothing}
         syms::Vector{Symbol}
@@ -41,7 +40,7 @@ function maketype(abstracttype,
         jac::Union{Function,Nothing}
         paramjac::Union{Function,Nothing}
         jac_prototype::Nothing
-        symjac::Union{Matrix{Expr},Nothing}
+        symjac::Union{Matrix{Union{Expr,Symbol,Number}},Nothing}
         reactions::Vector{ReactionStruct}
         syms_to_ints::OrderedDict{Symbol,Int}
         params_to_ints::OrderedDict{Symbol,Int}

--- a/src/reaction_network.jl
+++ b/src/reaction_network.jl
@@ -558,7 +558,7 @@ end
 #Makes the Jacobian.
 function calculate_jac(symjac::Matrix{Union{Expr,Symbol,Number}}, reactants::OrderedDict{Symbol,Int}, parameters::OrderedDict{Symbol,Int})
     func_body = Expr(:block)
-    for j = 1:size(symjac)[1], i = 1:size(symjac)[2]
+    for j = 1:size(symjac)[2], i = 1:size(symjac)[1]
         push!(func_body.args, :(internal___var___J[$i,$j] = $(recursive_replace!(symjac[i,j],(reactants,:internal___var___u), (parameters, :internal___var___p)))))        
     end
     push!(func_body.args,:(return internal___var___J))

--- a/src/reaction_network.jl
+++ b/src/reaction_network.jl
@@ -451,7 +451,7 @@ function clean_subtractions(ex::Expr)
 end
 
 #Recursively traverses an expression and removes things like X^1, 1*X. Will not actually have any affect on the expression when used as a function, but will make it much easier to look at it for debugging, as well as if it is transformed to LaTeX code.
-function recursive_clean!(expr::Any)
+function recursive_clean!(expr::Union{Expr,Symbol,Number})
     (expr == :no___noise___scaling) && (return 1)
     (typeof(expr)!=Expr) && (return expr)
     for i = 1:length(expr.args)
@@ -491,7 +491,7 @@ function recursive_clean!(expr::Any)
 end
 
 #Recursively traverses an expression and replace instances of variables and parmaters with things that the DifferentialEquations packakes simulation algorithms can understand. E.g. X --> u[1], kB1 --> p[1] etc.
-function recursive_replace!(expr::Any, replace_requests::Tuple{OrderedDict{Symbol,Int},Symbol}...)
+function recursive_replace!(expr::Union{Expr,Symbol,Number}, replace_requests::Tuple{OrderedDict{Symbol,Int},Symbol}...)
     if typeof(expr) == Symbol
         for rr in replace_requests
             (haskey(rr[1],expr)) && (return :($(rr[2])[$(rr[1][expr])]))
@@ -505,7 +505,7 @@ function recursive_replace!(expr::Any, replace_requests::Tuple{OrderedDict{Symbo
 end
 
 #Recursively traverses an expression and replaces a symbol with another.
-function recursive_replace!(expr::Any, replace_requests::Dict{Symbol,Symbol})
+function recursive_replace!(expr::Union{Expr,Symbol,Number}, replace_requests::Dict{Symbol,Symbol})
     if typeof(expr) == Symbol
         haskey(replace_requests,expr) && return replace_requests[expr]
     elseif typeof(expr) == Expr

--- a/src/reaction_network.jl
+++ b/src/reaction_network.jl
@@ -143,7 +143,7 @@ end
 function gensde_exprs(reactions, reactants, parameters, scale_noise)
     g_expr   = get_g(reactions, reactants, scale_noise)
     g        = make_func(g_expr, reactants, parameters)
-    g_funcs  = [element.args[2] for element in g_expr]
+    g_funcs  = Union{Expr,Symbol,Number}[element.args[2] for element in g_expr]
     p_matrix = zeros(length(reactants), length(reactions))
 
     (g_expr,g,g_funcs,p_matrix)
@@ -154,7 +154,7 @@ function genode_exprs(reactions, reactants, parameters, syms; build_jac=true,
                                                               build_symfuncs=true)
     f_expr                = get_f(reactions, reactants)
     f                     = make_func(f_expr, reactants, parameters)
-    f_rhs                 = [element.args[2] for element in f_expr]
+    f_rhs                 = Union{Expr,Symbol,Number}[element.args[2] for element in f_expr]
     symjac, jac, paramjac = build_jac ? get_jacs(f_rhs, syms, reactants, parameters) : (nothing,nothing,nothing)
     f_symfuncs            = build_symfuncs ? hcat([SymEngine.Basic(f) for f in f_rhs]) : nothing
 
@@ -345,7 +345,7 @@ function get_g(reactions::Vector{ReactionStruct}, reactants::OrderedDict{Symbol,
     g = Vector{Expr}(undef,length(reactions)*length(reactants))
     idx = 0
     for reactant in keys(reactants), i = 1:length(reactions)
-            g[idx += 1] = recursive_clean!(:(internal_var___du[$(reactants[reactant]),$i] = $scale_noise * $(get_stoch_diff(reactions[i],reactant)) * sqrt(abs($(deepcopy(reactions[i].rate_DE))))))
+        g[idx += 1] = recursive_clean!(:(internal_var___du[$(reactants[reactant]),$i] = $scale_noise * $(get_stoch_diff(reactions[i],reactant)) * sqrt(abs($(deepcopy(reactions[i].rate_DE))))))
     end
     return g
 end
@@ -385,7 +385,7 @@ end
 
 #Creates expressions for jump affects and rates. Also creates and array with MassAction, ConstantRate and VariableRate Jumps.
 function get_jumps(reactions::Vector{ReactionStruct}, reactants::OrderedDict{Symbol,Int}, parameters::OrderedDict{Symbol,Int}; minimal_jumps=false)
-    rates = Vector{Any}(undef,length(reactions))
+    rates = Vector{Union{Expr,Symbol,Number}}(undef,length(reactions))
     affects = Vector{Vector{Expr}}(undef,length(reactions))
     jumps = Expr(:tuple)
     reg_rates = Expr(:block)
@@ -395,7 +395,7 @@ function get_jumps(reactions::Vector{ReactionStruct}, reactants::OrderedDict{Sym
         rates[idx += 1] = recursive_clean!(reaction.rate_SSA)
         affects[idx] = Vector{Expr}(undef,0)
         reactant_set = union(getfield.(reaction.products, :reactant),getfield.(reaction.substrates, :reactant))
-        foreach(r -> push!(affects[idx],:(@inbounds integrator.u[$(reactants[r])] += $(get_stoch_diff(reaction,r)))), reactant_set)
+        foreach(r -> push!(affects[idx], :(integrator.u[$(reactants[r])] += $(get_stoch_diff(reaction,r)))), reactant_set)
         syntax_rate = recursive_replace!(deepcopy(rates[idx]), (reactants,:internal_var___u), (parameters, :internal_var___p))
 
         if minimal_jumps && reaction.is_pure_mass_action
@@ -408,7 +408,7 @@ function get_jumps(reactions::Vector{ReactionStruct}, reactants::OrderedDict{Sym
         else
             recursive_contains(:t,rates[idx]) ? push!(jumps.args,Expr(:call,:VariableRateJump)) : push!(jumps.args,Expr(:call,:ConstantRateJump))
             push!(jumps.args[idx].args, :((internal_var___u,internal_var___p,t) -> @inbounds $syntax_rate))
-            push!(jumps.args[idx].args, :(integrator -> $(expr_arr_to_block(deepcopy(affects[idx])))))
+            push!(jumps.args[idx].args, :(integrator -> @inbounds $(expr_arr_to_block(deepcopy(affects[idx])))))
         end
         push!(reg_rates.args,:(@inbounds internal_var___out[$idx]= $syntax_rate))
         foreach(r -> push!(reg_c.args,:(@inbounds internal_var___dc[$(reactants[r]),$idx]=$(get_stoch_diff(reaction,r)))), reactant_set)
@@ -536,7 +536,7 @@ function recursive_content(ex,syms::Vector{Symbol},content::Vector{Symbol})
 end
 
 #Makes the various jacobian elements required.
-function get_jacs(f_rhs::Vector{Expr}, syms::Vector{Symbol}, reactants::OrderedDict{Symbol,Int}, parameters::OrderedDict{Symbol,Int})
+function get_jacs(f_rhs::Vector{Union{Expr,Symbol,Number}}, syms::Vector{Symbol}, reactants::OrderedDict{Symbol,Int}, parameters::OrderedDict{Symbol,Int})
     symjac = calculate_symjac(deepcopy(f_rhs), syms)
     jac = calculate_jac(deepcopy(symjac), reactants, parameters)
     paramjac = calculate_paramjac(deepcopy(f_rhs), reactants, parameters)
@@ -544,35 +544,36 @@ function get_jacs(f_rhs::Vector{Expr}, syms::Vector{Symbol}, reactants::OrderedD
 end
 
 #Makes the Symbolic Jacobian.
-function calculate_symjac(f_rhs::Vector{Expr}, syms)
+function calculate_symjac(f_rhs::Vector{Union{Expr,Symbol,Number}}, syms)
     n = length(syms); internal_vars = [Symbol(:internal_variable___,var) for var in syms]
-    symjac = Matrix{SymEngine.Basic}(undef, n, n);
     symfuncs = [SymEngine.Basic(recursive_replace!(f,Dict(zip(syms,internal_vars)))) for f in f_rhs]
-    for i = 1:n, j = 1:n
-        symjac[i,j] = diff(symfuncs[i],internal_vars[j])
+    jacexprs = Matrix{Union{Expr,Symbol,Number}}(undef, n, n)
+    for j = 1:n, i = 1:n
+        symjacij = diff(symfuncs[i],internal_vars[j])
+        jacexprs[i,j] = :($(recursive_replace!(Meta.parse(string(symjacij)),Dict(zip(internal_vars,syms)))))
     end
-    return map(sym_entry -> :(1*$(recursive_replace!(Meta.parse(string(sym_entry)),Dict(zip(internal_vars,syms))))),symjac)
+    jacexprs
 end
 
 #Makes the Jacobian.
-function calculate_jac(symjac::Matrix{Expr}, reactants::OrderedDict{Symbol,Int}, parameters::OrderedDict{Symbol,Int})
+function calculate_jac(symjac::Matrix{Union{Expr,Symbol,Number}}, reactants::OrderedDict{Symbol,Int}, parameters::OrderedDict{Symbol,Int})
     func_body = Expr(:block)
-    for i = 1:size(symjac)[1], j = 1:size(symjac)[2]
-        push!(func_body.args,:(internal___var___pJ[$i,$j] = $(recursive_replace!(symjac[i,j],(reactants,:internal___var___u), (parameters, :internal___var___p)))))
-    end
-    push!(func_body.args,:(return internal___var___pJ))
-    return :((internal___var___pJ,internal___var___u,internal___var___p,t) -> @inbounds $func_body)
-end
-
-#Makes the Jacobian, with respect to parameter values.
-function calculate_paramjac(f_rhs::Vector{Expr}, reactants::OrderedDict{Symbol,Int}, parameters::OrderedDict{Symbol,Int})
-    func_body = Expr(:block)
-    for i = 1:length(reactants), j = 1:length(parameters)
-        paramjac_entry = Meta.parse(string(diff(SymEngine.Basic(f_rhs[i]), parameters.keys[j])))
-        push!(func_body.args,:(internal___var___J[$i,$j] = $(recursive_replace!(paramjac_entry,(reactants,:internal___var___u), (parameters, :internal___var___p)))))
+    for j = 1:size(symjac)[1], i = 1:size(symjac)[2]
+        push!(func_body.args, :(internal___var___J[$i,$j] = $(recursive_replace!(symjac[i,j],(reactants,:internal___var___u), (parameters, :internal___var___p)))))        
     end
     push!(func_body.args,:(return internal___var___J))
     return :((internal___var___J,internal___var___u,internal___var___p,t) -> @inbounds $func_body)
+end
+
+#Makes the Jacobian, with respect to parameter values.
+function calculate_paramjac(f_rhs::Vector{Union{Expr,Symbol,Number}}, reactants::OrderedDict{Symbol,Int}, parameters::OrderedDict{Symbol,Int})
+    func_body = Expr(:block)
+    for j = 1:length(parameters), i = 1:length(reactants)
+        paramjac_entry = Meta.parse(string(diff(SymEngine.Basic(f_rhs[i]), parameters.keys[j])))
+        push!(func_body.args, :(internal___var___pJ[$i,$j] = $(recursive_replace!(paramjac_entry,(reactants,:internal___var___u), (parameters, :internal___var___p)))))
+    end
+    push!(func_body.args,:(return internal___var___pJ))
+    return :((internal___var___pJ,internal___var___u,internal___var___p,t) -> @inbounds $func_body)
 end
 
 #Turns an array of expressions to a expression block with corresponding expressions.


### PR DESCRIPTION
This should (ultimately)
1. Fix the "+0" terms appearing in ODEs and other generated expressions.
2. Fix the "-1*" terms appearing in ODEs and other generated expressions. Here I just use the `clean_subtractions` function @korsbo wrote in Latexify which he said we should feel free to copy over.
3. Add `@inbounds` for the jump expressions it was still missing on.

@ChrisRackauckas or @TorkelE, would one of you mind taking a look that this seems reasonable? I tested on a few ODE and jump examples and didn't see issues with the generated expressions or solutions, but it would be good to have someone more comfortable working with expressions double check what I've done. If what I'm doing looks ok I'll update the Jacobian and noise generation functions too before merging.