### PR TITLE
Query interface updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ os:
   - linux
 #  - osx
 julia:
-  - 1.0
+  - 1.1
   - nightly
 matrix:
   allow_failures:

--- a/src/DiffEqBiological.jl
+++ b/src/DiffEqBiological.jl
@@ -23,7 +23,10 @@ include("problem.jl")
 export @reaction_network, @reaction_func, @min_reaction_network
 
 # functions to query network properties
-export speciesmap, paramsmap, get_substrate_stoich, get_net_stoich
+export speciesmap, paramsmap, numspecies, numreactions, numparams
+export odeexprs, jacobianexprs, noiseexprs, jumpexprs
+export get_substrate_stoich, get_net_stoich
+export rxtospecies_depgraph, speciestorx_depgraph, rxtorx_depgraph
 
 # functions to add mathematical equations to the network
 export addodes!, addsdes!, addjumps!

--- a/src/network_properties.jl
+++ b/src/network_properties.jl
@@ -2,6 +2,8 @@
 Functions for querying network properties.
 """
 
+######### Accessors: #########
+
 """
 Return a Dictionary mapping from species symbol to species index.
 """
@@ -15,6 +17,55 @@ Return a Dictionary mapping from parameter symbol to parameter index.
 function paramsmap(network)
     network.params_to_ints
 end
+
+function numspecies(network)
+    length(speciesmap(network))
+end
+
+function numreactions(network)
+    length(network.reactions)
+end
+
+function numparams(network)
+    length(paramsmap(network))
+end
+
+######### Generated Expressions: #########
+
+"""
+Return a vector of the ODE derivative expressions.
+"""
+function odeexprs(network)
+    isnothing(network.f_func) && error("Error, call addodes! first.")
+    network.f_func
+end
+
+"""
+Return a matrix with the ODE Jacobian expressions.
+"""
+function jacobianexprs(network)
+    isnothing(network.symjac) && error("Error, call addodes! first.")
+    network.symjac
+end
+
+"""
+Return a vector of the SDE noise expressions for each reaction.
+"""
+function noiseexprs(network)
+    isnothing(network.g_func) && error("Error, call addsdes! first.")
+    network.g_func
+end
+
+"""
+Return a tuple of the jump rates and affects expressions
+"""
+function jumpexprs(network)
+    (isnothing(network.jump_rate_expr) || isnothing(network.jump_affect_expr)) && error("Error, call addjumps! first.")
+    network.jump_rate_expr,network.jump_affect_expr
+end
+
+
+######### Reaction Properties: #########
 
 """
 Return a Vector of pairs, mapping ids of species that serve as substrates 
@@ -47,3 +98,67 @@ function get_net_stoich(rs::ReactionStruct, specmap)
     net_stoich
 end
 
+######### Network Properties: #########
+
+"""
+Returns a Vector{Vector{Int}} mapping a reaction index 
+to the indices of species that depend on it.
+"""
+function rxtospecies_depgraph(network)
+    specmap = speciesmap(network)
+
+    # map from a reaction to vector of species that depend on it
+    [sort!( [ns.first for ns in get_net_stoich(rx, specmap)] ) for rx in network.reactions]
+end
+
+"""
+Returns a Vector{Vector{Int}} mapping a species index 
+to the indices of reactions that depend on it.
+"""
+function speciestorx_depgraph(network)
+    numrxs  = numreactions(network)    
+    specmap = speciesmap(network)
+
+    # map from a species to reactions that depend on it
+    spectorxs = [Vector{Int}() for i=1:numspecies(network)]
+    for rx in 1:numrxs
+        for specsym in network.reactions[rx].dependants
+            push!(spectorxs[specmap[specsym]], rx)
+        end
+    end
+    foreach(stor -> sort!(stor), spectorxs)
+
+    spectorxs
+end
+
+"""
+Returns a Vector{Vector{Int}} mapping a reaction index
+to the indices of reactions that depend on it.
+"""
+function rxtorx_depgraph(network, sptorxsmap=nothing)
+    sptorxs = isnothing(sptorxsmap) ? speciestorx_depgraph(network) : sptorxsmap
+    numrxs = numreactions(network)
+    dep_sets = [SortedSet{Int}() for n = 1:numrxs]
+
+    # dg as vector of sets
+    for rx in 1:numrxs
+        net_stoich = get_net_stoich(network.reactions[rx], speciesmap(network))
+
+        for (spec,stoich) in net_stoich
+            for dependent_rx in sptorxs[spec]
+                push!(dep_sets[rx], dependent_rx)
+            end
+        end
+
+        # every reaction should depend on itself
+        push!(dep_sets[rx], rx)
+    end
+
+    # dg as vector of vectors
+    dep_graph = Vector{Vector{Int}}(undef, numrxs)
+    for rx in 1:numrxs
+        dep_graph[rx] = [dep for dep in dep_sets[rx]]
+    end
+
+    dep_graph
+end

--- a/test/networkquery_test.jl
+++ b/test/networkquery_test.jl
@@ -4,7 +4,7 @@ using DiffEqBiological, DiffEqJump, Test
 # mixed systems will be reordered when generating jump problems!
 
 # pure mass action
-rnm = @reaction_network rnmtype begin
+dnanetwork = @reaction_network begin
     c1, G --> G + M
     c2, M --> M + P
     c3, M --> 0
@@ -18,16 +18,16 @@ rnpar = [.09, .05, .001, .0009, .00001, .0005, .005, .9]
 varlabels = ["G", "M", "P", "P2","P2G"]
 u0 = [1000, 0, 0, 0,0]
 tf = 4000.
-prob = DiscreteProblem(rnm, u0, (0.0, tf), rnpar)
-jprob = JumpProblem(prob, RSSA(), rnm)
-@test all(rxtospecies_depgraph(rnm) .== jprob.discrete_jump_aggregation.jumptovars_map)
-@test all(speciestorx_depgraph(rnm) .== jprob.discrete_jump_aggregation.vartojumps_map)
+prob = DiscreteProblem(dnanetwork, u0, (0.0, tf), rnpar)
+jprob = JumpProblem(prob, RSSA(), dnanetwork)
+@test all(rxtospecies_depgraph(dnanetwork) .== jprob.discrete_jump_aggregation.jumptovars_map)
+@test all(speciestorx_depgraph(dnanetwork) .== jprob.discrete_jump_aggregation.vartojumps_map)
 
-jprob = JumpProblem(prob, NRM(), rnm)
-@test all(DiffEqBiological.rxtorx_depgraph(rnm) .== jprob.discrete_jump_aggregation.dep_gr)
+jprob = JumpProblem(prob, NRM(), dnanetwork)
+@test all(DiffEqBiological.rxtorx_depgraph(dnanetwork) .== jprob.discrete_jump_aggregation.dep_gr)
 
 # pure ConstantRateJump
-rnc = @reaction_network rnctype begin
+hillnetwork = @reaction_network begin
     hillr(m₃,α,K,n), ∅ --> m₁
     hillr(m₁,α,K,n), ∅ --> m₂
     hill(m₂,α,K,n), ∅ --> m₃
@@ -35,10 +35,10 @@ end α K η
 p = (1.,1.,1.)
 u0 = [10,10,10]
 tf = 10.
-prob = DiscreteProblem(rnc, u0, (0.0, tf), rnpar)
-jprob = JumpProblem(prob, RSSA(), rnc)
-@test all(rxtospecies_depgraph(rnc) .== jprob.discrete_jump_aggregation.jumptovars_map)
-@test all(speciestorx_depgraph(rnc) .== jprob.discrete_jump_aggregation.vartojumps_map)
+prob = DiscreteProblem(hillnetwork, u0, (0.0, tf), rnpar)
+jprob = JumpProblem(prob, RSSA(), hillnetwork)
+@test all(rxtospecies_depgraph(hillnetwork) .== jprob.discrete_jump_aggregation.jumptovars_map)
+@test all(speciestorx_depgraph(hillnetwork) .== jprob.discrete_jump_aggregation.vartojumps_map)
 
-jprob = JumpProblem(prob, NRM(), rnc)
-@test all(DiffEqBiological.rxtorx_depgraph(rnc) .== jprob.discrete_jump_aggregation.dep_gr)
+jprob = JumpProblem(prob, NRM(), hillnetwork)
+@test all(DiffEqBiological.rxtorx_depgraph(hillnetwork) .== jprob.discrete_jump_aggregation.dep_gr)

--- a/test/networkquery_test.jl
+++ b/test/networkquery_test.jl
@@ -1,0 +1,44 @@
+using DiffEqBiological, DiffEqJump, Test
+
+# only should agree for pure MassAction or pure ConstantRateJumps
+# mixed systems will be reordered when generating jump problems!
+
+# pure mass action
+rn = @reaction_network gnrdtype begin
+    c1, G --> G + M
+    c2, M --> M + P
+    c3, M --> 0
+    c4, P --> 0
+    c5, 2P --> P2
+    c6, P2 --> 2P
+    c7, P2 + G --> P2G
+    c8, P2G --> P2 + G
+end c1 c2 c3 c4 c5 c6 c7 c8
+rnpar = [.09, .05, .001, .0009, .00001, .0005, .005, .9]
+varlabels = ["G", "M", "P", "P2","P2G"]
+u0 = [1000, 0, 0, 0,0]
+tf = 4000.
+prob = DiscreteProblem(rn, u0, (0.0, tf), rnpar)
+jprob = JumpProblem(prob, RSSA(), rn)
+@test all(rxtospecies_depgraph(rn) .== jprob.discrete_jump_aggregation.jumptovars_map)
+@test all(speciestorx_depgraph(rn) .== jprob.discrete_jump_aggregation.vartojumps_map)
+
+jprob = JumpProblem(prob, NRM(), rn)
+@test all(DiffEqBiological.rxtorx_depgraph(rn) .== jprob.discrete_jump_aggregation.dep_gr)
+
+# pure ConstantRateJump
+rn = @reaction_network begin
+    hillr(m₃,α,K,n), ∅ --> m₁
+    hillr(m₁,α,K,n), ∅ --> m₂
+    hill(m₂,α,K,n), ∅ --> m₃
+end α K η
+p = (1.,1.,1.)
+u0 = [10,10,10]
+tf = 10.
+prob = DiscreteProblem(rn, u0, (0.0, tf), rnpar)
+jprob = JumpProblem(prob, RSSA(), rn)
+@test all(rxtospecies_depgraph(rn) .== jprob.discrete_jump_aggregation.jumptovars_map)
+@test all(speciestorx_depgraph(rn) .== jprob.discrete_jump_aggregation.vartojumps_map)
+
+jprob = JumpProblem(prob, NRM(), rn)
+@test all(DiffEqBiological.rxtorx_depgraph(rn) .== jprob.discrete_jump_aggregation.dep_gr)

--- a/test/networkquery_test.jl
+++ b/test/networkquery_test.jl
@@ -27,7 +27,7 @@ jprob = JumpProblem(prob, NRM(), rn)
 @test all(DiffEqBiological.rxtorx_depgraph(rn) .== jprob.discrete_jump_aggregation.dep_gr)
 
 # pure ConstantRateJump
-rn = @reaction_network begin
+rn2 = @reaction_network begin
     hillr(m₃,α,K,n), ∅ --> m₁
     hillr(m₁,α,K,n), ∅ --> m₂
     hill(m₂,α,K,n), ∅ --> m₃
@@ -35,10 +35,10 @@ end α K η
 p = (1.,1.,1.)
 u0 = [10,10,10]
 tf = 10.
-prob = DiscreteProblem(rn, u0, (0.0, tf), rnpar)
-jprob = JumpProblem(prob, RSSA(), rn)
-@test all(rxtospecies_depgraph(rn) .== jprob.discrete_jump_aggregation.jumptovars_map)
-@test all(speciestorx_depgraph(rn) .== jprob.discrete_jump_aggregation.vartojumps_map)
+prob = DiscreteProblem(rn2, u0, (0.0, tf), rnpar)
+jprob = JumpProblem(prob, RSSA(), rn2)
+@test all(rxtospecies_depgraph(rn2) .== jprob.discrete_jump_aggregation.jumptovars_map)
+@test all(speciestorx_depgraph(rn2) .== jprob.discrete_jump_aggregation.vartojumps_map)
 
-jprob = JumpProblem(prob, NRM(), rn)
-@test all(DiffEqBiological.rxtorx_depgraph(rn) .== jprob.discrete_jump_aggregation.dep_gr)
+jprob = JumpProblem(prob, NRM(), rn2)
+@test all(DiffEqBiological.rxtorx_depgraph(rn2) .== jprob.discrete_jump_aggregation.dep_gr)

--- a/test/networkquery_test.jl
+++ b/test/networkquery_test.jl
@@ -4,7 +4,7 @@ using DiffEqBiological, DiffEqJump, Test
 # mixed systems will be reordered when generating jump problems!
 
 # pure mass action
-rn = @reaction_network gnrdtype begin
+rnm = @reaction_network rnmtype begin
     c1, G --> G + M
     c2, M --> M + P
     c3, M --> 0
@@ -18,16 +18,16 @@ rnpar = [.09, .05, .001, .0009, .00001, .0005, .005, .9]
 varlabels = ["G", "M", "P", "P2","P2G"]
 u0 = [1000, 0, 0, 0,0]
 tf = 4000.
-prob = DiscreteProblem(rn, u0, (0.0, tf), rnpar)
-jprob = JumpProblem(prob, RSSA(), rn)
-@test all(rxtospecies_depgraph(rn) .== jprob.discrete_jump_aggregation.jumptovars_map)
-@test all(speciestorx_depgraph(rn) .== jprob.discrete_jump_aggregation.vartojumps_map)
+prob = DiscreteProblem(rnm, u0, (0.0, tf), rnpar)
+jprob = JumpProblem(prob, RSSA(), rnm)
+@test all(rxtospecies_depgraph(rnm) .== jprob.discrete_jump_aggregation.jumptovars_map)
+@test all(speciestorx_depgraph(rnm) .== jprob.discrete_jump_aggregation.vartojumps_map)
 
-jprob = JumpProblem(prob, NRM(), rn)
-@test all(DiffEqBiological.rxtorx_depgraph(rn) .== jprob.discrete_jump_aggregation.dep_gr)
+jprob = JumpProblem(prob, NRM(), rnm)
+@test all(DiffEqBiological.rxtorx_depgraph(rnm) .== jprob.discrete_jump_aggregation.dep_gr)
 
 # pure ConstantRateJump
-rn2 = @reaction_network begin
+rnc = @reaction_network rnctype begin
     hillr(m₃,α,K,n), ∅ --> m₁
     hillr(m₁,α,K,n), ∅ --> m₂
     hill(m₂,α,K,n), ∅ --> m₃
@@ -35,10 +35,10 @@ end α K η
 p = (1.,1.,1.)
 u0 = [10,10,10]
 tf = 10.
-prob = DiscreteProblem(rn2, u0, (0.0, tf), rnpar)
-jprob = JumpProblem(prob, RSSA(), rn2)
-@test all(rxtospecies_depgraph(rn2) .== jprob.discrete_jump_aggregation.jumptovars_map)
-@test all(speciestorx_depgraph(rn2) .== jprob.discrete_jump_aggregation.vartojumps_map)
+prob = DiscreteProblem(rnc, u0, (0.0, tf), rnpar)
+jprob = JumpProblem(prob, RSSA(), rnc)
+@test all(rxtospecies_depgraph(rnc) .== jprob.discrete_jump_aggregation.jumptovars_map)
+@test all(speciestorx_depgraph(rnc) .== jprob.discrete_jump_aggregation.vartojumps_map)
 
-jprob = JumpProblem(prob, NRM(), rn2)
-@test all(DiffEqBiological.rxtorx_depgraph(rn2) .== jprob.discrete_jump_aggregation.dep_gr)
+jprob = JumpProblem(prob, NRM(), rnc)
+@test all(DiffEqBiological.rxtorx_depgraph(rnc) .== jprob.discrete_jump_aggregation.dep_gr)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,6 +11,7 @@ using Test
   @time @testset "Steady state solver" begin include("steady_state.jl") end
   @time @testset "Mass Action Jumps" begin include("mass_act_jump_tests.jl") end
   @time @testset "Other Tests" begin include("misc_tests.jl") end
+  @time @testset "Network query tests" begin include("networkquery_test.jl") end
 end
 
 # min macro tests


### PR DESCRIPTION
This adds more exported accessors for querying network properties, along with several functions to calculate dependency graphs. 

As we fill this in users should be able to rely less on directly accessing the reaction_network fields, which will be helpful if and when we convert the backend to using ModelingToolkit. (We can just update these functions as appropriate.)

This won't pass tests till a new DiffEqJump release incorporating [67](https://github.com/JuliaDiffEq/DiffEqJump.jl/pull/67). In either case I'll leave it open for a day in case anyone wants to comment on the accessor names. 