### PR TITLE
- Replace several instances of "Any" with "ExprValues".

### DIFF
--- a/src/DiffEqBiological.jl
+++ b/src/DiffEqBiological.jl
@@ -12,7 +12,7 @@ using Parameters
 @reexport using DiffEqBase, DiffEqJump
 using Compat
 
-const ExprValues = Union{Expr,Symbol,Float64,Int64}                   
+const ExprValues = Union{Expr,Symbol,Float64,Int}                   
 
 include("reaction_network.jl")
 include("maketype.jl")

--- a/src/DiffEqBiological.jl
+++ b/src/DiffEqBiological.jl
@@ -10,8 +10,9 @@ using MacroTools
 using DataStructures
 using Parameters
 @reexport using DiffEqBase, DiffEqJump
-
 using Compat
+
+const ExprValues = Union{Expr,Symbol,Float64,Int64}                   
 
 include("reaction_network.jl")
 include("maketype.jl")

--- a/src/maketype.jl
+++ b/src/maketype.jl
@@ -16,7 +16,7 @@ function maketype(abstracttype,
                   jac = nothing,
                   paramjac = nothing,
                   jac_prototype = nothing,
-                  symjac=Matrix{Union{Expr,Symbol,Number}}(undef,0,0),
+                  symjac=Matrix{ExprValues}(undef,0,0),
                   reactions=Vector{ReactionStruct}(undef,0),
                   syms_to_ints = OrderedDict{Symbol,Int}(),
                   params_to_ints = OrderedDict{Symbol,Int}(),
@@ -26,13 +26,13 @@ function maketype(abstracttype,
 
     typeex = :(mutable struct $name <: $(abstracttype)
         f::Union{Function,Nothing}
-        f_func::Union{Vector{Union{Expr,Symbol,Number}},Nothing}
+        f_func::Union{Vector{ExprValues},Nothing}
         f_symfuncs::Union{Matrix{SymEngine.Basic},Nothing}
         g::Union{Function,Nothing}
-        g_func::Union{Vector{Union{Expr,Symbol,Number}},Nothing}
+        g_func::Union{Vector{ExprValues},Nothing}
         jumps::Union{Tuple{Vararg{DiffEqJump.AbstractJump}},Nothing}
         regular_jumps::Union{RegularJump,Nothing}
-        jump_rate_expr::Union{Tuple{Union{Expr,Symbol,Number},Vararg{Union{Expr,Symbol,Number}}},Nothing}
+        jump_rate_expr::Union{Tuple{ExprValues,Vararg{ExprValues}},Nothing}
         jump_affect_expr::Union{Tuple{Vector{Expr},Vararg{Vector{Expr}}},Nothing}
         p_matrix::Union{Array{Float64,2},Nothing}
         syms::Vector{Symbol}
@@ -40,7 +40,7 @@ function maketype(abstracttype,
         jac::Union{Function,Nothing}
         paramjac::Union{Function,Nothing}
         jac_prototype::Nothing
-        symjac::Union{Matrix{Union{Expr,Symbol,Number}},Nothing}
+        symjac::Union{Matrix{ExprValues},Nothing}
         reactions::Vector{ReactionStruct}
         syms_to_ints::OrderedDict{Symbol,Int}
         params_to_ints::OrderedDict{Symbol,Int}

--- a/src/reaction_network.jl
+++ b/src/reaction_network.jl
@@ -90,8 +90,6 @@ no_mass_arrows = Set{Symbol}([:⇐, :⟽, :⇒, :⟾, :⇔, :⟺])      #Using t
 
 funcdict = Dict{Symbol, Function}()                             #Stores user defined functions.
 
-const ExprValues = Union{Expr,Symbol,Number}                    #Generalised type for expression.
-
 #Coordination function, actually does all the work of the macro.
 function coordinate(name, ex::Expr, p, scale_noise)
 


### PR DESCRIPTION
Added `const ExprValues = Union{Expr,Symbol,Number}` and replaced it in all appropriate places. Should not be any `Any` left now.