### PR TITLE
bug fix

### DIFF
--- a/src/reaction_network.jl
+++ b/src/reaction_network.jl
@@ -227,7 +227,7 @@ struct ReactionStruct
         new(sub, prod, rate, rate_DE, rate_SSA, [], use_mass_kin)
     end
     function ReactionStruct(r::ReactionStruct, syms::Vector{Symbol})
-        deps = recursive_content(r.rate_DE,syms,Vector{Symbol}())
+        deps = sort!(unique!(recursive_content(r.rate_DE,syms,Vector{Symbol}())))
         is_ma = r.is_pure_mass_action && (length(recursive_content(r.rate_org,syms,Vector{Symbol}()))==0)
         new(r.substrates, r.products, r.rate_org, r.rate_DE, r.rate_SSA, deps, is_ma)
     end
@@ -335,7 +335,14 @@ function get_f(reactions::Vector{ReactionStruct}, reactants::OrderedDict{Symbol,
         end
     end
 
-    foreach(line -> line.args[2] = clean_subtractions(line.args[2]), f)
+    for line in f        
+        if length(line.args[2].args) == 1
+            @assert line.args[2].args[1] == :+
+            line.args[2] = 0
+        else 
+            line.args[2] = clean_subtractions(line.args[2])
+        end
+    end
 
     return f
 end


### PR DESCRIPTION
Fixes [108](https://github.com/JuliaDiffEq/DiffEqBiological.jl/issues/108) and another bug:

1.`rn.reactions[i].dependents` could end up with repeated symbols from reactions like:
```
k*X, X+Y --> W
```
which gave `[:X,:X,:Y]`.
2. A system of the form
```julia
rn = @reaction_network begin
       k, X + 3Y --> X + W
end k
```
was leading to problems. The generated ODE rhs expression for dX/dt only contained a `+()` expression. This should take care of that by replacing the ODE rhs with just zero.

I left an assert in the code in case I've missed a possibility and one could get a different expression with no arguments.