### PR TITLE
Incremental model construction

### DIFF
--- a/src/DiffEqBiological.jl
+++ b/src/DiffEqBiological.jl
@@ -21,14 +21,17 @@ include("massaction_jump_utils.jl")
 include("problem.jl")
 
 # reaction network macro
-export @reaction_network, @reaction_func, @min_reaction_network
+export @reaction_network, @reaction_func, @min_reaction_network, @empty_reaction_network
 
 # functions to query network properties
-export speciesmap, paramsmap, numspecies, numreactions, numparams
+export species, params, speciesmap, paramsmap, numspecies, numreactions, numparams
 export oderhsfun, jacfun, paramjacfun, odefun, noisefun, sdefun, jumps, regularjumps
 export odeexprs, jacobianexprs, noiseexprs, jumpexprs, rateexpr, oderatelawexpr, ssaratelawexpr
 export substratestoich, productstoich, netstoich, ismassaction, dependants, dependents, substrates, products
 export rxtospecies_depgraph, speciestorx_depgraph, rxtorx_depgraph
+
+# functions to extend empty_ and min_ reaction_networks
+export addspecies!, addparam!, add_scale_noise_param!, addreaction!
 
 # functions to add mathematical equations to the network
 export addodes!, addsdes!, addjumps!

--- a/src/maketype.jl
+++ b/src/maketype.jl
@@ -232,6 +232,7 @@ function addreaction!(rn::DiffEqBase.AbstractReactionNetwork, rateexpr::ExprValu
     ex = Expr(:block, :(($rateexpr, $rxexpr)))
     newrxs = get_reactions(ex)
     foreach(rx -> push!(rn.reactions,ReactionStruct(rx, species(rn))), newrxs)
+    nothing
 end
 
 """
@@ -289,6 +290,7 @@ function addreaction!(rn::DiffEqBase.AbstractReactionNetwork, rateexpr::ExprValu
     end
     
     push!(rn.reactions, ReactionStruct(substrates, products, rateexpr, rate_DE, rate_SSA, dependents, ismassaction))
+    nothing
 end
 
 

--- a/src/maketype.jl
+++ b/src/maketype.jl
@@ -133,6 +133,107 @@ function gentypefun_exprs(name; esc_exprs=true, gen_inplace=true, gen_outofplace
     exprs
 end
 
+######################## functions to extend a network ####################
+
+"""
+    addspecies!(network, species::Symbol)
+
+Given an AbstractReaction network, add the species corresponding to the passed
+in symbol to the network (if it is not already defined). 
+""" 
+function addspecies!(rn::DiffEqBase.AbstractReactionNetwork, species::Symbol)
+    if !haskey(speciesmap(rn), species)        
+        push!(species(rn), species)
+        sidx = numspecies(rn) + 1
+        push!(speciesmap(rn), species => sidx)
+    end
+    nothing
+end
+
+"""
+    addspecies!(network, speciesname::String)
+
+Given an AbstractReaction network, add the species with name given by the passed
+in string to the network (if it is not already defined.
+"""
+addspecies!(rn::DiffEqBase.AbstractReactionNetwork, speciesname::String) = addspecies!(rn, Symbol(speciesname))
+
+"""
+    addparam!(network, param::Symbol)
+
+Given an AbstractReaction network, add the parameter corresponding to the passed
+in symbol to the network (if it is not already defined).
+"""
+function addparam!(rn::DiffEqBase.AbstractReactionNetwork, param::Symbol)
+    if !haskey(paramsmap(rn), param)
+        push!(params(rn), param)
+        pidx = numparams(rn) + 1
+        push!(paramsmap(rn), param => pidx)
+    end
+    nothing
+end
+
+"""
+    addparam!(network, paramname::String)
+
+Given an AbstractReaction network, add the parameter with name given by the
+passed in string to the network (if it is not already defined).
+"""
+addparam!(rn::DiffEqBase.AbstractReactionNetwork, param::String) = addparam!(rn, Symbol(param))
+
+"""
+    add_scale_noise_param!(network, scale_noise::Symbol)
+
+Given an AbstractReaction network, add the parameter corresponding to the passed
+in symbol to the network (if it is not already defined), and register it as the
+noise scaling coefficient.
+"""
+function add_scale_noise_param!(rn::DiffEqBase.AbstractReactionNetwork, scale_noise::Symbol)    
+    rn.scale_noise = scale_noise
+
+    if !haskey(paramsmap(rn), scale_noise)
+        push!(params(rn), scale_noise)
+        pidx = numparams(rn) + 1
+        push!(paramsmap(rn), scale_noise => pidx)
+    end
+    nothing
+end
+
+"""
+    add_scale_noise_param!(network, scale_noise_name::String)
+
+Given an AbstractReaction network, add the parameter with the passed in string
+as its name to the network (if it is not already defined), and register it as
+the noise scaling coefficient.
+"""
+add_scale_noise_param!(rn::DiffEqBase.AbstractReactionNetwork, scale_noise_name::String) = add_scale_noise_param!(rn, Symbol(scale_noise_name))
+
+"""
+    addreaction!(network, rateexpr::Union{Expr,Symbol,Int,Float64}, rxexpr::Expr)
+
+Given an AbstractReaction network, add a reaction with the passed in rate and
+reaction expressions. i.e. a reaction of the form
+```julia
+k*X, 2X + Y --> 2W
+```
+would have `rateexpr=:(k*X)` and `rxexpr=:(2X + Y --> W)`, 
+```julia
+10.5, 0 --> X
+````
+would have `rateexpr=10.5` and `rxexpr=:(0 --> X)`, and
+```julia
+k, X+X --> Z
+`````
+would have `rateexpr=:k` and `rxexpr=:(X+X --> Z)`.
+
+All normal DSL type functions should be supported.
+"""
+function addreaction!(rn::DiffEqBase.AbstractReactionNetwork, rateexpr::ExprValues, rxexpr::Expr)
+   nothing 
+end
+
+############## Adding ODES/SDE/Jumps for problems ################
+
 """
     addodes!(network; build_jac=true, build_symfuncs=true)
 

--- a/src/maketype.jl
+++ b/src/maketype.jl
@@ -136,16 +136,16 @@ end
 ######################## functions to extend a network ####################
 
 """
-    addspecies!(network, species::Symbol)
+    addspecies!(network, speciessym::Symbol)
 
 Given an AbstractReaction network, add the species corresponding to the passed
 in symbol to the network (if it is not already defined). 
 """ 
-function addspecies!(rn::DiffEqBase.AbstractReactionNetwork, species::Symbol)
-    if !haskey(speciesmap(rn), species)        
-        push!(species(rn), species)
+function addspecies!(rn::DiffEqBase.AbstractReactionNetwork, sp::Symbol)
+    if !haskey(speciesmap(rn), sp)        
+        push!(species(rn), sp)
         sidx = numspecies(rn) + 1
-        push!(speciesmap(rn), species => sidx)
+        push!(speciesmap(rn), sp => sidx)
     end
     nothing
 end
@@ -226,10 +226,12 @@ k, X+X --> Z
 `````
 would have `rateexpr=:k` and `rxexpr=:(X+X --> Z)`.
 
-All normal DSL type functions should be supported.
+All normal DSL reaction definition notation should be supported.
 """
 function addreaction!(rn::DiffEqBase.AbstractReactionNetwork, rateexpr::ExprValues, rxexpr::Expr)
-   nothing 
+    ex = Expr(:block, :(($rateexpr, $rxexpr)))
+    newrxs = get_reactions(ex)
+    foreach(rx -> push!(rn.reactions,ReactionStruct(rx, species(rn))), newrxs)
 end
 
 ############## Adding ODES/SDE/Jumps for problems ################

--- a/src/maketype.jl
+++ b/src/maketype.jl
@@ -240,7 +240,7 @@ end
     addodes!(network; build_jac=true, build_symfuncs=true)
 
 Extend an `AbstractReactionNetwork` generated with the `@min_reaction_network`
-macro with everything needed to use ODE solvers.
+or `@empty_reaction_network` macros with everything needed to use ODE solvers.
 
 Optional kwargs can be used to disable the construction of additional ODE solver
 components.
@@ -268,8 +268,8 @@ end
     addsdes!(network; build_jac=true, build_symfuncs=true)
 
 Extend an `AbstractReactionNetwork` generated with the `@min_reaction_network`
-macro with everything needed to use SDE solvers.
-
+or `@empty_reaction_network` macros with everything needed to use SDE solvers.
+    
 Optional kwargs can be used to disable the construction of additional SDE solver
 components.
 """
@@ -294,8 +294,8 @@ end
     addjumps!(network; build_jumps=true, build_regular_jumps=true, minimal_jumps=false)
 
 Extend an `AbstractReactionNetwork` generated with the `@min_reaction_network`
-macro with everything needed to use jump SSA solvers.
-
+or `@empty_reaction_network` macros with everything needed to use jump SSA solvers.
+    
 Optional kwargs can be used to disable the construction of additional jump solver
 components.
 

--- a/src/maketype.jl
+++ b/src/maketype.jl
@@ -219,11 +219,11 @@ k*X, 2X + Y --> 2W
 would have `rateexpr=:(k*X)` and `rxexpr=:(2X + Y --> W)`, 
 ```julia
 10.5, 0 --> X
-````
+```
 would have `rateexpr=10.5` and `rxexpr=:(0 --> X)`, and
 ```julia
 k, X+X --> Z
-`````
+```
 would have `rateexpr=:k` and `rxexpr=:(X+X --> Z)`.
 
 All normal DSL reaction definition notation should be supported.
@@ -236,26 +236,27 @@ function addreaction!(rn::DiffEqBase.AbstractReactionNetwork, rateexpr::ExprValu
 end
 
 """
-    addreaction!(network, rateexpr::Union{Expr,Symbol,Int,Float64}, rxexpr::Expr, substrates, products)
+    addreaction!(network, rateexpr::Union{Expr,Symbol,Int,Float64}, substrates, products)
 
-Given an AbstractReaction network, add a reaction with the passed in rate and
-expression, substrate stoichiometry, and product stoichiometry. Stoichiometries
+Given an AbstractReaction network, add a reaction with the passed in rate,
+`rateexpr`, substrate stoichiometry, and product stoichiometry. Stoichiometries
 are represented as tuples of `Pair{Symbol,Int}`. i.e. a reaction of the form
 ```julia
 k*X, 2X + Y --> 2W
 ```
-would have `rateexpr=:(k*X)`, substrates=(:X=>2, :Y=>2) and `products=(W=>2,)`, 
+would have `rateexpr=:(k*X)`, `substrates=(:X=>2, :Y=>2)`` and
+`products=(W=>2,)`, 
 ```julia
 10.5, 0 --> X
-````
+```
 would have `rateexpr=10.5`, `substrates=()` and `products=(:X=>1,)`, and
 ```julia
 k, X+X --> Z
-`````
+```
 would have `rateexpr=:k`, `substrates=(:X=>2,)` and `products=(:Z=>2,)`.
 
 All normal DSL reaction definition notation should be supported for the
-`rxexpr`.
+`rateexpr`.
 """
 function addreaction!(rn::DiffEqBase.AbstractReactionNetwork, rateexpr::ExprValues, 
                                         subs::Tuple{Vararg{Pair{Symbol,Int}}}, 

--- a/src/network_properties.jl
+++ b/src/network_properties.jl
@@ -3,6 +3,22 @@
 ######### Accessors: #########
 
 """
+    species(network)
+Given an `AbstractReactionNetwork`, return a vector of species symbols.
+"""
+function species(network)
+    network.syms
+end
+
+"""
+    params(network)
+Given an `AbstractReactionNetwork`, return a vector of parameter symbols.
+"""
+function params(network)
+    network.params
+end
+
+"""
     speciesmap(network)
 
 Given an `AbstractReactionNetwork`, return a Dictionary mapping from species

--- a/src/reaction_network.jl
+++ b/src/reaction_network.jl
@@ -94,6 +94,9 @@ macro min_reaction_network(ex::Expr, p...)
     min_coordinate(:min_reaction_network, MacroTools.striplines(ex), p, :no___noise___scaling)
 end
 
+macro empty_reaction_network(name::Symbol=:min_reaction_network)
+    min_coordinate(name, MacroTools.striplines(:(begin end)), (), :no___noise___scaling)
+end
 
 #################
 
@@ -144,7 +147,11 @@ function min_coordinate(name, ex::Expr, p, scale_noise)
 
     # Build the type
     exprs = Vector{Expr}(undef,0)
-    typeex,constructorex = maketype(DiffEqBase.AbstractReactionNetwork, name, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, syms, scale_noise; params=params, reactions=reactions, symjac=nothing, syms_to_ints=reactants, params_to_ints=parameters)
+    typeex,constructorex = maketype(DiffEqBase.AbstractReactionNetwork, name, nothing, nothing, 
+                                    nothing, nothing, nothing, nothing, nothing, nothing, 
+                                    nothing, nothing, syms, scale_noise; params=params, 
+                                    reactions=reactions, symjac=nothing, syms_to_ints=reactants, 
+                                    params_to_ints=parameters)
     push!(exprs,typeex)
     push!(exprs,constructorex)
 
@@ -193,8 +200,7 @@ function get_minnetwork(ex::Expr, p)
 end
 
 #Generates a vector containing a number of reaction structures, each containing the infromation about one reaction.
-function get_reactions(ex::Expr)
-    reactions = Vector{ReactionStruct}(undef,0)
+function get_reactions(ex::Expr, reactions = Vector{ReactionStruct}(undef,0))    
     for line in ex.args
         (line.head != :tuple) && (continue)
         (rate,r_line) = line.args

--- a/src/reaction_network.jl
+++ b/src/reaction_network.jl
@@ -52,8 +52,10 @@ Example systems:
     @reaction_network
 
 Generates a subtype of an `AbstractReactionNetwork` that encodes a chemical
-reaction network, and complete ODE, SDE and jump representations
-of the system.
+reaction network, and complete ODE, SDE and jump representations of the system.
+See the [Chemical Reaction Model
+docs](http://docs.juliadiffeq.org/latest/models/biological.html) for details on
+parameters to the macro.
 """
 macro reaction_network(name, ex::Expr, p...)
     coordinate(name, MacroTools.striplines(ex), p, :no___noise___scaling)
@@ -73,11 +75,12 @@ end
 ################# query-based macros:
 
 """
-    @min_reaction_network
+    @min_reaction_network 
 
 Generates a subtype of an `AbstractReactionNetwork` that only encodes a chemical
 reaction network. Use [`addodes!`](@ref), [`addsdes!`](@ref) or
-[`addjumps!`](@ref) to complete the network for specific problem types.
+[`addjumps!`](@ref) to complete the network for specific problem types. It accepts
+the same arguments as [`@reaction_network`](@ref).
 """
 macro min_reaction_network(name, ex::Expr, p...)
     min_coordinate(name, MacroTools.striplines(ex), p, :no___noise___scaling)
@@ -94,6 +97,16 @@ macro min_reaction_network(ex::Expr, p...)
     min_coordinate(:min_reaction_network, MacroTools.striplines(ex), p, :no___noise___scaling)
 end
 
+"""
+    @empty_reaction_network networktype
+
+Generates a subtype of an `AbstractReactionNetwork` that encodes an empty
+chemical reaction network. `networktype` is an optional parameter that specifies
+the type of the generated network. Use [`addspecies!`(@ref), [`addparam!`](@ref)
+and [`addreaction!`](@ref) to extend the network.  Use [`addodes!`](@ref),
+[`addsdes!`](@ref) or [`addjumps!`](@ref) to complete the network for specific
+problem types.
+"""
 macro empty_reaction_network(name::Symbol=:min_reaction_network)
     min_coordinate(name, MacroTools.striplines(:(begin end)), (), :no___noise___scaling)
 end

--- a/src/reaction_network.jl
+++ b/src/reaction_network.jl
@@ -102,7 +102,7 @@ end
 
 Generates a subtype of an `AbstractReactionNetwork` that encodes an empty
 chemical reaction network. `networktype` is an optional parameter that specifies
-the type of the generated network. Use [`addspecies!`(@ref), [`addparam!`](@ref)
+the type of the generated network. Use [`addspecies!`](@ref), [`addparam!`](@ref)
 and [`addreaction!`](@ref) to extend the network.  Use [`addodes!`](@ref),
 [`addsdes!`](@ref) or [`addjumps!`](@ref) to complete the network for specific
 problem types.

--- a/src/reaction_network.jl
+++ b/src/reaction_network.jl
@@ -240,6 +240,12 @@ struct ReactionStruct
     dependants::Vector{Symbol}
     is_pure_mass_action::Bool
 
+    function ReactionStruct(s::Vector{ReactantStruct}, p::Vector{ReactantStruct}, 
+                            ro::ExprValues, rde::ExprValues, rssa::ExprValues, 
+                            dep::Vector{Symbol}, isma::Bool)
+        new(s,p,ro,rde,rssa,dep,isma)
+    end
+
     function ReactionStruct(sub_line::ExprValues, prod_line::ExprValues, rate::ExprValues, use_mass_kin::Bool)
         sub = add_reactants!(sub_line,1,Vector{ReactantStruct}(undef,0))
         prod = add_reactants!(prod_line,1,Vector{ReactantStruct}(undef,0))
@@ -249,7 +255,7 @@ struct ReactionStruct
         new(sub, prod, rate, rate_DE, rate_SSA, [], use_mass_kin)
     end
     function ReactionStruct(r::ReactionStruct, syms::Vector{Symbol})
-        deps = sort!(unique!(recursive_content(r.rate_DE,syms,Vector{Symbol}())))
+        deps = unique!(recursive_content(r.rate_DE,syms,Vector{Symbol}()))
         is_ma = r.is_pure_mass_action && (length(recursive_content(r.rate_org,syms,Vector{Symbol}()))==0)
         new(r.substrates, r.products, r.rate_org, r.rate_DE, r.rate_SSA, deps, is_ma)
     end

--- a/test/addreactions_test.jl
+++ b/test/addreactions_test.jl
@@ -1,3 +1,20 @@
+function testnetwork(rn, rn2)
+    rxids = 1:numreactions(rn)
+    rxids2 = 1:numreactions(rn2)
+    @test params(rn) == params(rn2)
+    @test paramsmap(rn) == paramsmap(rn2)
+    @test species(rn) == species(rn2)
+    @test speciesmap(rn) == speciesmap(rn2)
+    @test dependents.(rn,rxids) == dependents.(rn2,rxids2)
+    @test substrates.(rn,rxids) == substrates.(rn2,rxids2)
+    @test products.(rn,rxids) == products.(rn2,rxids2)
+    @test rateexpr.(rn,rxids) == rateexpr.(rn2,rxids2)
+    @test oderatelawexpr.(rn,rxids) == oderatelawexpr.(rn2,rxids2)
+    @test ssaratelawexpr.(rn,rxids) == ssaratelawexpr.(rn2,rxids2)
+    @test ismassaction.(rn,rxids) == ismassaction.(rn2,rxids2)
+end
+
+# baseline network to test against
 repressilator = @min_reaction_network begin
     hillr(P₃,α,K,n), ∅ --> m₁
     hillr(P₁,α,K,n), ∅ --> m₃
@@ -9,33 +26,11 @@ repressilator = @min_reaction_network begin
     β*P₂, 2m₁ + 3P₁ --> P₂
 end α K n δ γ β μ;
 numrxs = numreactions(repressilator)
-rxids = 1:numrxs
-
-function testnetwork(rn)
-    rxidsmin = 1:numreactions(rn)
-    @test params(rn) == params(repressilator)
-    @test paramsmap(rn) == paramsmap(repressilator)
-    @test species(rn) == species(repressilator)
-    @test speciesmap(rn) == speciesmap(repressilator)
-    @test dependents.(rn,rxidsmin) == dependents.(repressilator,rxids)
-    @test substrates.(rn,rxidsmin) == substrates.(repressilator,rxids)
-    @test products.(rn,rxidsmin) == products.(repressilator,rxids)
-    @test rateexpr.(rn,rxidsmin) == rateexpr.(repressilator,rxids)
-    @test oderatelawexpr.(rn,rxidsmin) == oderatelawexpr.(repressilator,rxids)
-    @test ssaratelawexpr.(rn,rxidsmin) == ssaratelawexpr.(repressilator,rxids)
-    @test ismassaction.(rn,rxidsmin) == ismassaction.(repressilator,rxids)
-end
 
 # empty network
 rmin = @empty_reaction_network
-
-# parameters
 foreach(param -> addparam!(rmin, param), params(repressilator))
-
-# species
 foreach(spec -> addspecies!(rmin, spec), species(repressilator))
-
-# reactions
 addreaction!(rmin, :(hillr(P₃,α,K,n)), :(∅ --> m₁) )
 addreaction!(rmin, :(hillr(P₁,α,K,n)), :(∅ --> m₃) )
 addreaction!(rmin, :((δ,γ)), :(m₁ ↔ ∅) )
@@ -44,11 +39,26 @@ addreaction!(rmin, :β, :(m₁ --> m₁ + P₁) )
 addreaction!(rmin, 10., :(m₃ --> m₃ + P₃) )
 addreaction!(rmin, 2, :(P₁ --> ∅) )
 addreaction!(rmin, :(β*P₂), :(2m₁ + 3P₁ --> P₂) )  
+testnetwork(rmin, repressilator)
 
-testnetwork(rmin)
+# empty network stoichiometry interface
+rmin = @empty_reaction_network
+foreach(param -> addparam!(rmin, param), params(repressilator))
+foreach(spec -> addspecies!(rmin, spec), species(repressilator))
+addreaction!(rmin, :(hillr(P₃,α,K,n)), (), (:m₁=>1,))
+addreaction!(rmin, :(hillr(P₁,α,K,n)), (), (:m₃=>1,) )
+addreaction!(rmin, :δ, (:m₁ => 1,), ())
+addreaction!(rmin, :γ, (), (:m₁ => 1,))
+addreaction!(rmin, :δ, (:m₃ => 1,), ())
+addreaction!(rmin, :γ, (), (:m₃ => 1,))
+addreaction!(rmin, :β, (:m₁=>1,), (:m₁=>1, :P₁=>1) )
+addreaction!(rmin, 10., (:m₃=>1,), (:m₃=>1, :P₃=>1) )
+addreaction!(rmin, 2, (:P₁=>1,),() )
+addreaction!(rmin, :(β*P₂), (:m₁=>2,:P₁=>3), (:P₂=>1,) )  
+testnetwork(rmin, repressilator)
+
 
 # partial min_reaction_network
-
 rmin2 = @min_reaction_network begin
     hillr(P₃,α,K,n), ∅ --> m₁
     hillr(P₁,α,K,n), ∅ --> m₃
@@ -57,18 +67,26 @@ rmin2 = @min_reaction_network begin
     β, m₁ --> m₁ + P₁
     10., m₃ --> m₃ + P₃
 end α K n δ γ β;
-
-# params, should only add missing ones
 foreach(param -> addparam!(rmin2, param), params(repressilator))
-
-# species, should only add missing ones
 foreach(spec -> addspecies!(rmin2, spec), species(repressilator))
-
-# reactions
 addreaction!(rmin2, 2, :(P₁ --> ∅) )
 addreaction!(rmin2, :(β*P₂), :(2m₁ + 3P₁ --> P₂) )  
+testnetwork(rmin2, repressilator)
 
-testnetwork(rmin2)
+# partial min_reaction_network, stoichiometry interface
+rmin2 = @min_reaction_network begin
+    hillr(P₃,α,K,n), ∅ --> m₁
+    hillr(P₁,α,K,n), ∅ --> m₃
+    (δ,γ), m₁ ↔ ∅
+    (δ,γ), m₃ ↔ ∅
+    β, m₁ --> m₁ + P₁
+    10., m₃ --> m₃ + P₃
+end α K n δ γ β;
+foreach(param -> addparam!(rmin2, param), params(repressilator))
+foreach(spec -> addspecies!(rmin2, spec), species(repressilator))
+addreaction!(rmin2, 2, (:P₁=>1,), ())
+addreaction!(rmin2, :(β*P₂), (:m₁=>2,:P₁=>3), (:P₂=>1,) )  
+testnetwork(rmin2, repressilator)
 
 
 # simple example to test numerical agreement of solutions
@@ -100,3 +118,24 @@ addodes!(minrn)
 moprob = ODEProblem(minrn, u0, tspan, p)
 msol = solve(moprob,Tsit5(), abstol=1e-10, reltol=1e-10)
 @test norm(msol .- fsol, Inf) < 1e-7
+
+
+# another simple example to test numerical agreement of solutions
+# using stoichiometry interface
+fullrn = @reaction_network begin
+    (X^2/6,1.0), X ↔ Y + X
+end
+u0 = [1000.,1000.]
+tspan = (0.,5e-4)
+foprob = ODEProblem(fullrn, u0, tspan)
+fsol = solve(foprob,Tsit5(), abstol=1e-10, reltol=1e-10)
+
+emptyrn = @empty_reaction_network
+addspecies!(emptyrn, :X)
+addspecies!(emptyrn, "Y")
+addreaction!(emptyrn, :(X^2/6), (:X=>1,), (:X=>1, :Y=>1))
+addreaction!(emptyrn, 1.0, (:X=>1,:Y=>1), (:X=>1,))
+addodes!(emptyrn)
+eoprob = ODEProblem(emptyrn, u0, tspan)
+esol = solve(eoprob,Tsit5(), abstol=1e-10, reltol=1e-10)
+@test norm(esol .- fsol, Inf) < 1e-7

--- a/test/addreactions_test.jl
+++ b/test/addreactions_test.jl
@@ -1,0 +1,102 @@
+repressilator = @min_reaction_network begin
+    hillr(P₃,α,K,n), ∅ --> m₁
+    hillr(P₁,α,K,n), ∅ --> m₃
+    (δ,γ), m₁ ↔ ∅
+    (δ,γ), m₃ ↔ ∅
+    β, m₁ --> m₁ + P₁
+    10., m₃ --> m₃ + P₃
+    2, P₁ --> ∅
+    β*P₂, 2m₁ + 3P₁ --> P₂
+end α K n δ γ β μ;
+numrxs = numreactions(repressilator)
+rxids = 1:numrxs
+
+function testnetwork(rn)
+    rxidsmin = 1:numreactions(rn)
+    @test params(rn) == params(repressilator)
+    @test paramsmap(rn) == paramsmap(repressilator)
+    @test species(rn) == species(repressilator)
+    @test speciesmap(rn) == speciesmap(repressilator)
+    @test dependents.(rn,rxidsmin) == dependents.(repressilator,rxids)
+    @test substrates.(rn,rxidsmin) == substrates.(repressilator,rxids)
+    @test products.(rn,rxidsmin) == products.(repressilator,rxids)
+    @test rateexpr.(rn,rxidsmin) == rateexpr.(repressilator,rxids)
+    @test oderatelawexpr.(rn,rxidsmin) == oderatelawexpr.(repressilator,rxids)
+    @test ssaratelawexpr.(rn,rxidsmin) == ssaratelawexpr.(repressilator,rxids)
+    @test ismassaction.(rn,rxidsmin) == ismassaction.(repressilator,rxids)
+end
+
+# empty network
+rmin = @empty_reaction_network
+
+# parameters
+foreach(param -> addparam!(rmin, param), params(repressilator))
+
+# species
+foreach(spec -> addspecies!(rmin, spec), species(repressilator))
+
+# reactions
+addreaction!(rmin, :(hillr(P₃,α,K,n)), :(∅ --> m₁) )
+addreaction!(rmin, :(hillr(P₁,α,K,n)), :(∅ --> m₃) )
+addreaction!(rmin, :((δ,γ)), :(m₁ ↔ ∅) )
+addreaction!(rmin, :((δ,γ)), :(m₃ ↔ ∅) )
+addreaction!(rmin, :β, :(m₁ --> m₁ + P₁) )
+addreaction!(rmin, 10., :(m₃ --> m₃ + P₃) )
+addreaction!(rmin, 2, :(P₁ --> ∅) )
+addreaction!(rmin, :(β*P₂), :(2m₁ + 3P₁ --> P₂) )  
+
+testnetwork(rmin)
+
+# partial min_reaction_network
+
+rmin2 = @min_reaction_network begin
+    hillr(P₃,α,K,n), ∅ --> m₁
+    hillr(P₁,α,K,n), ∅ --> m₃
+    (δ,γ), m₁ ↔ ∅
+    (δ,γ), m₃ ↔ ∅
+    β, m₁ --> m₁ + P₁
+    10., m₃ --> m₃ + P₃
+end α K n δ γ β;
+
+# params, should only add missing ones
+foreach(param -> addparam!(rmin2, param), params(repressilator))
+
+# species, should only add missing ones
+foreach(spec -> addspecies!(rmin2, spec), species(repressilator))
+
+# reactions
+addreaction!(rmin2, 2, :(P₁ --> ∅) )
+addreaction!(rmin2, :(β*P₂), :(2m₁ + 3P₁ --> P₂) )  
+
+testnetwork(rmin2)
+
+
+# simple example to test numerical agreement of solutions
+fullrn = @reaction_network begin
+    (k*X*(X-1)*(X-2),Y * X), X + 2X ⟺ Y+ X
+end k
+p = (1/6,)
+u0 = [1000.,1000.]
+tspan = (0.,5e-4)
+foprob = ODEProblem(fullrn, u0, tspan, p)
+fsol = solve(foprob,Tsit5(), abstol=1e-10, reltol=1e-10)
+
+emptyrn = @empty_reaction_network
+addspecies!(emptyrn, :X)
+addspecies!(emptyrn, "Y")
+addparam!(emptyrn, :k)
+addreaction!(emptyrn, :((k*X*(X-1)*(X-2),Y * X)), :(X + 2X ⟺ Y+ X))
+addodes!(emptyrn)
+eoprob = ODEProblem(emptyrn, u0, tspan, p)
+esol = solve(eoprob,Tsit5(), abstol=1e-10, reltol=1e-10)
+@test norm(esol .- fsol, Inf) < 1e-7
+
+minrn = @min_reaction_network begin
+    X*Y, X + Y ⟾ X + 2X
+end
+addparam!(minrn, "k")
+addreaction!(minrn, :(k*X*(X-1)*(X-2)), :(X + 2X ⟾ Y + X))
+addodes!(minrn)
+moprob = ODEProblem(minrn, u0, tspan, p)
+msol = solve(moprob,Tsit5(), abstol=1e-10, reltol=1e-10)
+@test norm(msol .- fsol, Inf) < 1e-7

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-using Test, Statistics, Random
+using Test, Statistics, Random, LinearAlgebra
 using DiffEqBiological, DiffEqBase
 using OrdinaryDiffEq, StochasticDiffEq, DiffEqJump, SteadyStateDiffEq
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -29,4 +29,5 @@ end
 # tests that handle both macros
 @time begin
   @time @testset "Discrete Problem" begin include("discreteproblem_test.jl") end
+  @time @testset "Add Reactions API" begin include("addreactions_test.jl") end
 end


### PR DESCRIPTION
This adds a set of functions for extending a `min_reaction_network` with more species/parameters/reactions, or creating an empty reaction network and then extending it. New functions:

* `@empty_reaction_network`
* `addspecies!`
* `addparam!`
* `addreaction!`
* `add_scale_noise_param!`

I think `addreaction!` could be made more efficient -- right now the user passes an `ExprValues` for the parameter and an `Expr` for the reaction. Basically the two components of one line of the normal macro. So the following two networks should have all of the `min_reaction_network` defined fields equal

```julia
minrn = @min_reaction_network begin
    (k*X*(X-1)*(X-2),Y * X), X + 2X ⟺ Y+ X
end k
```
and
```julia
emptyrn = @empty_reaction_network
addspecies!(emptyrn, :X)
addspecies!(emptyrn, "Y")
addparam!(emptyrn, :k)
addreaction!(emptyrn, :((k*X*(X-1)*(X-2),Y * X)), :(X + 2X ⟺ Y+ X))
```

The add* functions can also be used on a `min_reaction_network`, as long as `addodes!` and such hasn't already been called. (That might work too, but I haven't checked.) Once species, params and reactions have been added the addodes! and such functions can be called.

One caveat, any species used in the `min_reaction_network` should appear within the reactions and not just the rate `ExprValues` or they won't be added to the species list. i.e. don't do
```
minrn = @min_reaction_network begin
    k*X, Y --> 0
end k
```
If `X` is then added as a species later the dependents of the above reaction will be incorrect. (The general rule is species and params should be defined before any reaction using them.)

I'll again leave this open for a day for comments (and can leave it open longer if anyone wants more time to review it).
