### PR TITLE
further optimize addreaction! for large systems

### DIFF
--- a/src/maketype.jl
+++ b/src/maketype.jl
@@ -285,7 +285,7 @@ function addreaction!(rn::DiffEqBase.AbstractReactionNetwork, rateexpr::ExprValu
     else # isa Expr
 
         # mimicing ReactionStruct constructor for now, but this should be optimized...
-        newdeps = unique!(recursive_content(rate_DE, species(rn), Vector{Symbol}()))
+        newdeps = unique!(recursive_content(rate_DE, speciesmap(rn), Vector{Symbol}()))
         ismassaction = length(newdeps)==length(intersect!(dependents, newdeps)) ? true : false
         dependents = newdeps
     end


### PR DESCRIPTION
For large systems (i.e. many species, certainly O(1000)), it looks to on average be noticeably faster to use `haskey` with the OrderedDict mapping species syms to ints, rather than use `in` with the unordered sym vector. I'll more quantitatively assess how much this helps on a full network once I update `ReactionNetworkImporters.jl` to use the incremental interface.

I only updated this on the incremental interface as it will be slightly slower on small networks, such as one would commonly specify with `@reaction_network`. The speed difference for something small like the repressilator though should be unnoticeable in general...