### PR TITLE
replace species names in SymEngine with temp symbols

### DIFF
--- a/test/make_model_test.jl
+++ b/test/make_model_test.jl
@@ -90,3 +90,16 @@ end p1 p2
 @test length(network6.syms) == 6
 @test typeof(network6) <: DiffEqBase.AbstractReactionNetwork
 @test typeof(network6) == reaction_network
+
+# test that can we construct a network that involves symengine constants as species names
+symengnet = @reaction_network begin
+    k1, I + E --> 2*A
+    k2, 2I --> 2E
+    k4*E*A, E + A ⇒ 0
+end k1 k2 k4
+realjac = DiffEqBiological.ExprValues[  
+    :(-(k1 * E) - 2 * (k2 * I))  :(-(k1 * I))  0
+    :(-(k1 * E) + 2 * (k2 * I))  :(-(k1 * I) - k4 * A)      :(-k4 * E)  
+    :(2 * (k1 * E))              :(2 * (k1 * I) - k4 * A)   :(-k4 * E)
+]
+@assert realjac == jacobianexprs(symengnet)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,7 +12,7 @@ using OrdinaryDiffEq, StochasticDiffEq, DiffEqJump, SteadyStateDiffEq
   @time @testset "Steady state solver" begin include("steady_state.jl") end
   @time @testset "Mass Action Jumps" begin include("mass_act_jump_tests.jl") end
   @time @testset "Other Tests" begin include("misc_tests.jl") end
-  @time @testset "Network query tests" begin include("networkquery_test.jl") end
+  @time @testset "Network query tests" begin include("networkquery_test.jl") end  
 end
 
 # min macro tests


### PR DESCRIPTION
This is a first step towards fixing #129, where symbols that correspond to constants in SymEngine lead to incorrect Jacobian terms. Note, this does not completely close the issue, as the same problem can crop up if parameter symbols correspond to SymEngine constants, and this problem also remains for species or parameter symbols when calculating the parameter Jacobian. This should bring us back to the same level of correctness we had on release 3.7.2.