### PR TITLE
add explicit size for sparse matrices 

### DIFF
--- a/src/maketype.jl
+++ b/src/maketype.jl
@@ -15,7 +15,6 @@ function maketype(abstracttype,
                   params = Symbol[],
                   jac = nothing,
                   paramjac = nothing,
-                  jac_prototype = nothing,
                   symjac=Matrix{ExprValues}(undef,0,0),
                   reactions=Vector{ReactionStruct}(undef,0),
                   syms_to_ints = OrderedDict{Symbol,Int}(),
@@ -39,7 +38,6 @@ function maketype(abstracttype,
         params::Vector{Symbol}
         jac::Union{Function,Nothing}
         paramjac::Union{Function,Nothing}
-        jac_prototype::Nothing
         symjac::Union{Matrix{ExprValues},Nothing}
         reactions::Vector{ReactionStruct}
         syms_to_ints::OrderedDict{Symbol,Int}
@@ -65,7 +63,6 @@ function maketype(abstracttype,
                 $(Expr(:kw,:symjac,symjac)),
                 $(Expr(:kw,:jac,jac)),
                 $(Expr(:kw,:paramjac,paramjac)),
-                $(Expr(:kw,:jac_prototype,jac_prototype)),
                 $(Expr(:kw,:reactions,reactions)),
                 $(Expr(:kw,:syms_to_ints, syms_to_ints)),
                 $(Expr(:kw,:params_to_ints, params_to_ints)),
@@ -87,7 +84,6 @@ function maketype(abstracttype,
                         params,
                         jac,
                         paramjac,
-                        jac_prototype,
                         symjac,
                         reactions,
                         syms_to_ints,
@@ -341,13 +337,13 @@ function addodes!(rn::DiffEqBase.AbstractReactionNetwork; kwargs...)
     @unpack reactions, syms_to_ints, params_to_ints, syms = rn
 
     (f_expr, f, f_rhs, symjac, jac, paramjac, f_symfuncs, jac_prototype) = genode_exprs(reactions, syms_to_ints, params_to_ints, syms; kwargs...)
-    rn.f          = eval(f)
-    rn.f_func     = f_rhs
-    rn.jac        = eval(jac)
-    rn.paramjac   = eval(paramjac)
-    rn.symjac     = eval(symjac)
-    rn.f_symfuncs = f_symfuncs
-    rn.odefun     = ODEFunction(rn.f; jac=rn.jac, jac_prototype=jac_prototype, paramjac=rn.paramjac, syms=rn.syms)
+    rn.f             = eval(f)
+    rn.f_func        = f_rhs
+    rn.jac           = eval(jac)
+    rn.paramjac      = eval(paramjac)
+    rn.symjac        = eval(symjac)
+    rn.f_symfuncs    = f_symfuncs    
+    rn.odefun        = ODEFunction(rn.f; jac=rn.jac, jac_prototype=jac_prototype, paramjac=rn.paramjac, syms=rn.syms)
 
     # functor for evaluating f
     functor_exprs = gentypefun_exprs(typeof(rn), esc_exprs=false, gen_constructor=false)

--- a/src/reaction_network.jl
+++ b/src/reaction_network.jl
@@ -627,7 +627,7 @@ function calculate_jac(symjac::Matrix{ExprValues}, reactants::OrderedDict{Symbol
 end
 
 # convert Dict mapping (i,j) => val to sparse matrix
-function dict_to_sparsemat(d; vals=nothing)
+function dict_to_sparsemat(d, m, n; vals=nothing)
     V   = isnothing(vals) ? collect(values(d)) : vals
     len = length(d)
     I   = Vector{Int}(undef,len)
@@ -636,7 +636,7 @@ function dict_to_sparsemat(d; vals=nothing)
         I[i] = k[1]
         J[i] = k[2]
     end    
-    return sparse(I,J,V)
+    return sparse(I,J,V,m,n)
 end
 
 # create a sparse Jacobian
@@ -645,7 +645,7 @@ function calculate_sparse_jac(reactions, reactants, parameters)
     # get the elements and structure of sparse matrix
     jacexprs = Dict{Tuple{Int,Int},ExprValues}()
     jac_as_exprvalues!(jacexprs, reactions, reactants)
-    jac_prototype = dict_to_sparsemat(jacexprs, vals=ones(length(jacexprs)))
+    jac_prototype = dict_to_sparsemat(jacexprs, length(reactants), length(reactants), vals=ones(length(jacexprs)))
 
     # build the function
     jfun = Expr(:block)

--- a/test/make_model_test.jl
+++ b/test/make_model_test.jl
@@ -103,3 +103,17 @@ realjac = DiffEqBiological.ExprValues[
     :(2 * (k1 * E))              :(2 * (k1 * I) - k4 * A)   :(-k4 * E)
 ]
 @assert realjac == jacobianexprs(symengnet)
+
+
+# test that we can construct a network that involves a singular Jacobian
+network7 = @reaction_network begin
+    k1, I + E --> 2*B
+    k2, 2I --> 2E
+    k4*E*A, E + A ⇒ 0
+end k1 k2 k4
+network8 = @min_reaction_network begin
+    k1, I + E --> 2*B
+    k2, 2I --> 2E
+    k4*E*A, E + A ⇒ 0
+end k1 k2 k4
+addodes!(network8, sparse_jac=true)


### PR DESCRIPTION
Fixes the crash mentioned in [discourse](https://discourse.julialang.org/t/solving-highly-stiff-chemical-kinetics-ivp-using-diffeqbiological/25247/18), which was caused by having a system in which the generated Jacobian had a column of zeros leading to an incorrect size for the generated sparse matrix. Turns out I hadn't explicitly set the size of the generated sparse matrix.

I also removed the `jac_prototype` field from within the reaction network as it was not being used (and was explicitly typed as `Nothing` -- we instead use the field within the generated `ODEFunction`).